### PR TITLE
dfu: sector count changes only on diamond

### DIFF
--- a/bootloader/boards/diamond_main.conf
+++ b/bootloader/boards/diamond_main.conf
@@ -1,0 +1,3 @@
+# Max number of sector for an update
+# 448K (partition) / 2K (sector) = 224
+CONFIG_BOOT_MAX_IMG_SECTORS=256

--- a/bootloader/prj.conf
+++ b/bootloader/prj.conf
@@ -32,11 +32,6 @@ CONFIG_BOOT_BOOTSTRAP=n
 # CONFIG_TINYCRYPT_SHA256 is not set
 
 CONFIG_FLASH=y
-
-# Max number of sector for an update
-# 448K (partition) / 2K (sector) = 224
-CONFIG_BOOT_MAX_IMG_SECTORS=256
-
 ### Various Zephyr boards enable features that we don't want.
 # CONFIG_BT is not set
 # CONFIG_BT_CTLR is not set


### PR DESCRIPTION
sector count increased as we now use the external flash for the secondary partition.

Not the case on Pearl so this commit fixes this. 
