### PR TITLE
dfu: stack-allocated buffer increases runner stack size

### DIFF
--- a/lib/dfu/dfu.c
+++ b/lib/dfu/dfu.c
@@ -443,7 +443,7 @@ dfu_version_primary_get(struct image_version *ih_ver)
     ret = flash_area_open(DT_FIXED_PARTITION_ID(DT_NODELABEL(slot0_partition)),
                           &flash_area_p);
     if (ret) {
-        LOG_ERR("Unable to open primary slot");
+        LOG_ERR("Unable to open primary slot: %d", ret);
         ret = RET_ERROR_INTERNAL;
         goto exit;
     }
@@ -451,7 +451,7 @@ dfu_version_primary_get(struct image_version *ih_ver)
     ret = flash_area_read(flash_area_p, 0, &primary_slot_header,
                           sizeof(primary_slot_header));
     if (ret) {
-        LOG_ERR("Unable to read primary slot header");
+        LOG_ERR("Unable to read primary slot header: %d", ret);
         ret = RET_ERROR_INTERNAL;
         goto exit;
     }
@@ -486,7 +486,7 @@ dfu_version_secondary_get(struct image_version *ih_ver)
     ret = flash_area_open(DT_FIXED_PARTITION_ID(DT_ALIAS(secondary_slot)),
                           &flash_area_p);
     if (ret) {
-        LOG_ERR("Unable to open secondary slot");
+        LOG_ERR("Unable to open secondary slot: %d", ret);
         ret = RET_ERROR_INTERNAL;
         goto exit;
     }
@@ -494,7 +494,7 @@ dfu_version_secondary_get(struct image_version *ih_ver)
     ret = flash_area_read(flash_area_p, 0, &secondary_slot_header,
                           sizeof(secondary_slot_header));
     if (ret) {
-        LOG_ERR("Unable to read secondary slot");
+        LOG_ERR("Unable to read secondary slot: %d", ret);
         ret = RET_ERROR_INTERNAL;
         goto exit;
     }
@@ -502,6 +502,7 @@ dfu_version_secondary_get(struct image_version *ih_ver)
     // if flash is erased, no image present
     if (secondary_slot_header.ih_ver.iv_build_num == 0xFFFFFFFFLU &&
         secondary_slot_header.ih_ver.iv_revision == 0xFFFFLU) {
+        LOG_ERR("Secondary slot is erased");
         ret = RET_ERROR_NOT_FOUND;
         goto exit;
     }

--- a/lib/dfu/dfu.c
+++ b/lib/dfu/dfu.c
@@ -323,6 +323,9 @@ dfu_secondary_activate_temporarily(void)
 int
 dfu_secondary_check(uint32_t crc32)
 {
+    // buffer needed to read external Flash (diamond) and compute CRC32
+    uint8_t buf[DFU_FLASH_PAGE_SIZE];
+    uint32_t computed_crc = 0;
     int ret;
 
     // update header before checking
@@ -362,8 +365,6 @@ dfu_secondary_check(uint32_t crc32)
         img_size += tlv_magic.it_tlv_tot;
     }
 
-    uint8_t buf[DFU_FLASH_PAGE_SIZE];
-    uint32_t computed_crc = 0;
     // read entire flash area content to calculate CRC32
     for (size_t off = 0; off < img_size; off += DFU_FLASH_PAGE_SIZE) {
         size_t len = (img_size - off < DFU_FLASH_PAGE_SIZE)

--- a/lib/dfu/include/dfu.h
+++ b/lib/dfu/include/dfu.h
@@ -76,6 +76,10 @@ dfu_secondary_activate_temporarily(void);
 /**
  * Check image in secondary slot against a CRC32.
  * Use it to validate a new image has correctly been written on Flash.
+ *
+ * @warning this function allocates a flash-page sized buffer on the stack,
+ *          which may be large
+ *
  * @param crc32
  * @retval RET_ERROR_INVALID_STATE secondary slot not initialized or CRC32 does
  * not match

--- a/main_board/app/include/app_config.h
+++ b/main_board/app/include/app_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 ///////////////////////////////////////
-/// Threads ordered by priorities   ///
+/// Threads config                  ///
 ///////////////////////////////////////
 
 // work queue CONFIG_SYSTEM_WORKQUEUE_PRIORITY = -1
@@ -13,8 +13,9 @@
 #define THREAD_STACK_SIZE_POWER_MANAGEMENT 2048
 
 // Runner / default message processing
+// ⚠️ flash page buffer allocated on stack for CRC32 calculation
 #define THREAD_PRIORITY_RUNNER   6
-#define THREAD_STACK_SIZE_RUNNER 2048
+#define THREAD_STACK_SIZE_RUNNER 4096
 
 // Front unit RGB LEDs
 #define THREAD_PRIORITY_FRONT_UNIT_RGB_LEDS 7

--- a/main_board/app/src/optics/ir_camera_system/ir_camera_system.c
+++ b/main_board/app/src/optics/ir_camera_system/ir_camera_system.c
@@ -284,6 +284,8 @@ ir_camera_system_perform_focus_sweep(void)
             ir_camera_system_perform_focus_sweep_hw();
             ret = RET_SUCCESS;
         }
+    } else {
+        LOG_ERR("Focus sweep not performed, status: %d", ret);
     }
 
     return ret;

--- a/main_board/app/src/optics/ir_camera_system/ir_camera_system_tests.c
+++ b/main_board/app/src/optics/ir_camera_system/ir_camera_system_tests.c
@@ -392,7 +392,8 @@ ZTEST(hil, test_ir_eye_camera_focus_sweep)
     send_msg(&msg);
 
     int ret = k_sem_take(&camera_sweep_sem, K_MSEC(FOCUS_SWEEP_WAIT_TIME_MS));
-    zassert_ok(ret, "Timed out! Waited for %ums", FOCUS_SWEEP_WAIT_TIME_MS);
+    zassert_ok(ret, "Timed out! Waited for %ums. Semaphore count: %u",
+               FOCUS_SWEEP_WAIT_TIME_MS, k_sem_count_get(&camera_sweep_sem));
     zassert_equal(ir_camera_system_get_status(), RET_SUCCESS);
 }
 


### PR DESCRIPTION
A large page-sized buffer is needed to compute crc for external flash.

Stack allocation is preferred over static allocation to make this RAM chunk be usable by other runner-called functions.
