### PR TITLE
tools: added nix flake for convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ _htmresc/
 
 ## Environement
 .envrc
+.direnv/
 
 ## board-specific OpenOCD config that shouldn't be tracked
 ## copy-pasted from utils/debug/my_board.cfg.template

--- a/utils/env/.envrc.example
+++ b/utils/env/.envrc.example
@@ -1,0 +1,1 @@
+use flake ./utils/env

--- a/utils/env/flake.lock
+++ b/utils/env/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713145326,
+        "narHash": "sha256-m7+IWM6mkWOg22EC5kRUFCycXsXLSU7hWmHdmBfmC3s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "53a2c32bc66f5ae41a28d7a9a49d321172af621e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/utils/env/flake.nix
+++ b/utils/env/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "orb-firmware flake";
+  inputs = {
+    # Worlds largest repository of linux software
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    # Provides eachDefaultSystem and other utility functions
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, }:
+    # This helper function is used to more easily abstract
+    # over the host platform.
+    # See https://github.com/numtide/flake-utils#eachdefaultsystem--system---attrs
+    utils.lib.eachDefaultSystem (system:
+      let
+        p = {
+          # The platform that you are running nix on and building from
+          native = nixpkgs.legacyPackages.${system};
+          # The other platforms we support for cross compilation
+          arm-linux = nixpkgs.legacyPackages.aarch64-linux;
+          x86-linux = nixpkgs.legacyPackages.x86_64-linux;
+          arm-macos = nixpkgs.legacyPackages.aarch64-darwin;
+          x86-macos = nixpkgs.legacyPackages.x86_64-darwin;
+        };
+        pythonShell = (ps: with ps; [
+          pyocd
+          cmsis-pack-manager
+          cffi
+        ]);
+      in
+      # See https://nixos.wiki/wiki/Flakes#Output_schema
+      {
+        # Everything in here becomes your shell (nix develop)
+        devShells.default = p.native.mkShell {
+          # Nix makes the following list of dependencies available to the development
+          # environment.
+          buildInputs = (with p.native; [
+            protobuf
+            nixpkgs-fmt
+
+            (python3.withPackages pythonShell)
+            black
+
+            # This is missing on mac m1 nix, for some reason.
+            # see https://stackoverflow.com/a/69732679
+            libiconv
+          ]);
+
+          # The following sets up environment variables for the shell. These are used
+          # by the build.rs build scripts of the rust crates.
+          shellHook = ''
+            '';
+        };
+        # Lets you type `nix fmt` to format the flake.
+        formatter = p.native.nixpkgs-fmt;
+      }
+    );
+}


### PR DESCRIPTION
I use flakes to manage developer shells, so I figured I'd add a simple flake for setting up pyocd, protobuf, etc.