### PR TITLE
battery: add reading of SoH register

### DIFF
--- a/main_board/src/power/battery/battery_amber.c
+++ b/main_board/src/power/battery/battery_amber.c
@@ -585,7 +585,9 @@ battery_rx_thread()
                 BatteryStateOfHealth state_of_health = {0};
                 state_of_health.percentage = state_of_health_percentage;
 
-                publish_new(&state_of_health, sizeof(state_of_health), McuToJetson_battery_state_of_health_tag, CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
+                publish_new(&state_of_health, sizeof(state_of_health),
+                            McuToJetson_battery_state_of_health_tag,
+                            CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
             }
         }
 

--- a/main_board/src/pubsub/pubsub.c
+++ b/main_board/src/pubsub/pubsub.c
@@ -86,6 +86,9 @@ const struct sub_message_s sub_prios[] = {
     [McuToJetson_battery_info_max_values_tag] = {.priority = SUB_PRIO_STORE},
     [McuToJetson_battery_info_soc_and_statistics_tag] = {.priority =
                                                              SUB_PRIO_STORE},
+    [McuToJetson_cone_present_tag] = {.priority = SUB_PRIO_DISCARD},
+    [McuToJetson_memfault_event_tag] = {.priority = SUB_PRIO_DISCARD},
+    [McuToJetson_battery_state_of_health_tag] = {.priority = SUB_PRIO_DISCARD},
 };
 
 /* ISO-TP addresses + one CAN-FD address */

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
           - nanopb
           - hal_st
     - name: orb-messages
-      revision: 523a6c01dedb51d8fdbb8d59bab5cdf807439fed
+      revision: ea731c597ddf77c02e4f544453e73c90f195ed2c
       path: modules/orb-messages/public
     - name: priv-orb-messages
       revision: b2e01ac2c617cdbb1f1dc77ab49a4561d855cb11


### PR DESCRIPTION
Read State-of-Health register from Amber battery and send its value to Jetson.

fixes O-2426