### PR TITLE
version: add Mainboard B3

### DIFF
--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -233,7 +233,8 @@ power_configure_gpios(void)
 
     // Additional control signals for 3V3_SSD and 3V3_WIFI on EV5 and Diamond
     if (version == Hardware_OrbVersion_HW_VERSION_PEARL_EV5 ||
-        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2) {
+        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2 ||
+        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_B3) {
         if (!device_is_ready(supply_3v3_ssd_enable_gpio_spec.port) ||
             !device_is_ready(supply_3v3_wifi_enable_gpio_spec.port)) {
             return RET_ERROR_INTERNAL;
@@ -377,7 +378,8 @@ power_turn_on_power_supplies(void)
 
     // Additional control signals for 3V3_SSD and 3V3_WIFI on EV5 and Diamond
     if (version == Hardware_OrbVersion_HW_VERSION_PEARL_EV5 ||
-        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2) {
+        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2 ||
+        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_B3) {
         gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
         LOG_INF("3.3V SSD power supply enabled");
 
@@ -682,7 +684,8 @@ reboot_thread()
             // Additional control signals for 3V3_SSD and 3V3_WIFI on EV5 and
             // Diamond
             if (version == Hardware_OrbVersion_HW_VERSION_PEARL_EV5 ||
-                version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2) {
+                version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2 ||
+                version == Hardware_OrbVersion_HW_VERSION_DIAMOND_B3) {
                 gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 0);
                 gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 0);
             }

--- a/main_board/src/system/version/version.c
+++ b/main_board/src/system/version/version.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(version, CONFIG_VERSION_LOG_LEVEL);
  * Hardware version can be fetched using IO expander on the main board:
  * - v4.0 p10 = 0
  * - v4.1 p10 = 1
+ * - v4.2 p10 = 2
  **/
 
 #if defined(CONFIG_BOARD_PEARL_MAIN)
@@ -153,6 +154,9 @@ version_fetch_hardware_rev(Hardware *hw_version)
             break;
         case 1:
             version = Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2;
+            break;
+        case 2:
+            version = Hardware_OrbVersion_HW_VERSION_DIAMOND_B3;
             break;
         default:
             LOG_ERR("Unknown main board from IO expander: %d", hw_bits);

--- a/main_board/src/temperature/fan/fan.c
+++ b/main_board/src/temperature/fan/fan.c
@@ -187,7 +187,8 @@ fan_init(void)
                version == Hardware_OrbVersion_HW_VERSION_PEARL_EV5) {
         fan_specs = fan_ev3_specs;
 #elif defined(CONFIG_BOARD_DIAMOND_MAIN)
-    if (version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2) {
+    if (version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2 ||
+        version == Hardware_OrbVersion_HW_VERSION_DIAMOND_B3) {
         fan_specs = fan_diamond_specs;
 #endif
     } else {
@@ -215,7 +216,8 @@ fan_init(void)
         // + 239 (1% of available range of 60%)
         min_speed_pulse_width_ns = 16239;
 
-    } else if (version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2) {
+    } else if (version == Hardware_OrbVersion_HW_VERSION_DIAMOND_POC2 ||
+               version == Hardware_OrbVersion_HW_VERSION_DIAMOND_B3) {
         max_speed_pulse_width_ns = 40000;
 
         // min is 30% duty cycle = 0.3*40000

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
           - nanopb
           - hal_st
     - name: orb-messages
-      revision: 0cf4636b99211cdbebba3948776cbb8c351d45af
+      revision: 523a6c01dedb51d8fdbb8d59bab5cdf807439fed
       path: modules/orb-messages/public
     - name: priv-orb-messages
       revision: b2e01ac2c617cdbb1f1dc77ab49a4561d855cb11


### PR DESCRIPTION
Add support for Mainboard hardware version 4.2 which is used in the Diamond B3 build.

fixes O-2619