### PR TITLE
diamond: front-leds: build 3 to have 136 RGB LEDs (72 ring, 64 shroud)

### DIFF
--- a/boards/arm/diamond_main/diamond_main.dts
+++ b/boards/arm/diamond_main/diamond_main.dts
@@ -470,7 +470,7 @@
                 // not actually used by the SPI driver
                 duplex = <SPI_HALF_DUPLEX>;
 
-                num-leds = <72>;
+                num-leds = <136>;
             };
         };
 

--- a/boards/arm/diamond_main/diamond_main.dts
+++ b/boards/arm/diamond_main/diamond_main.dts
@@ -470,7 +470,7 @@
                 // not actually used by the SPI driver
                 duplex = <SPI_HALF_DUPLEX>;
 
-                num-leds = <99>;
+                num-leds = <72>;
             };
         };
 

--- a/drivers/led_strip/Kconfig.spi_rgb_led
+++ b/drivers/led_strip/Kconfig.spi_rgb_led
@@ -15,7 +15,7 @@ config SPI_RGB_LED_DIMMING
 config SPI_RGB_LED_BUFFER_SIZE
     int "Size of SPI RGB LED buffer"
     depends on SPI_RGB_LED
-    default 396
+    default 544
     help
       Size of the SPI RGB LED buffer in bytes. This is the maximum
       number of bytes that can be sent to the LED strip in one go.

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -31,8 +31,8 @@ static const struct device *const led_strip =
 // an LED strip update until the next IR LED pulse
 #define LED_STRIP_MAXIMUM_UPDATE_TIME_US 10000
 #else
-#define NUM_CENTER_LEDS 23
-#define INDEX_RING_ZERO 19 // 0º is at 19th LED
+#define NUM_CENTER_LEDS 64
+#define INDEX_RING_ZERO 0 // 0º is at 0th LED
 #endif
 #define NUM_RING_LEDS (NUM_LEDS - NUM_CENTER_LEDS)
 

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -25,14 +25,15 @@ static const struct device *const led_strip =
 #define NUM_LEDS DT_PROP(DT_NODELABEL(front_unit_rgb_leds), num_leds)
 #if defined(CONFIG_BOARD_PEARL_MAIN)
 #define NUM_CENTER_LEDS 9
-#define INDEX_RING_ZERO ((NUM_RING_LEDS * 3 / 4))
+#define INDEX_RING_ZERO ((NUM_RING_LEDS * 3 / 4)) // 0º is at the 3 o'clock position
 // Maximum amount of time for LED strip update
 // It's also the minimum amount of time we need to trigger
 // an LED strip update until the next IR LED pulse
 #define LED_STRIP_MAXIMUM_UPDATE_TIME_US 10000
 #else
 #define NUM_CENTER_LEDS 64
-#define INDEX_RING_ZERO 0 // 0º is at 0th LED
+// 0º (3 o'clock position) is at 53rd LED on Front Unit 6.2
+#define INDEX_RING_ZERO 53
 #endif
 #define NUM_RING_LEDS (NUM_LEDS - NUM_CENTER_LEDS)
 


### PR DESCRIPTION
will ditch support for Diamond PoC2

fixes O-2608
