### PR TITLE
build: new variable make board selection easier

### DIFF
--- a/main_board/CMakeLists.txt
+++ b/main_board/CMakeLists.txt
@@ -33,6 +33,13 @@ set_property(
 
 set_property(GLOBAL PROPERTY CSTD gnu11)
 
+# optional Orb variable allows to select the board
+if ("$ENV{ORB}" STREQUAL "pearl")
+    set(ENV{BOARD} pearl_main)
+elseif ("$ENV{ORB}" STREQUAL "diamond")
+    set(ENV{BOARD} diamond_main)
+endif ()
+
 # Load board before Zephyr loads it to get some custom/private board configuration.
 # Private config is not available publicly as the name suggests and contains
 # paths to private keys.

--- a/main_board/CMakeLists.txt
+++ b/main_board/CMakeLists.txt
@@ -35,8 +35,10 @@ set_property(GLOBAL PROPERTY CSTD gnu11)
 
 # optional Orb variable allows to select the board
 if ("$ENV{ORB}" STREQUAL "pearl")
+    unset(BOARD CACHE)
     set(ENV{BOARD} pearl_main)
 elseif ("$ENV{ORB}" STREQUAL "diamond")
+    unset(BOARD CACHE)
     set(ENV{BOARD} diamond_main)
 endif ()
 


### PR DESCRIPTION
when setting ORB=pearl or ORB=diamond, the board
is selected automatically.
it allows to use one profile per Orb on CLion:
the profile selects the board when loading the CMakeLists.txt. We still have to create a new profile for Debug/Release