### PR TITLE
battery: send shutdown scheduled

### DIFF
--- a/main_board/src/pubsub/pubsub.c
+++ b/main_board/src/pubsub/pubsub.c
@@ -89,6 +89,7 @@ const struct sub_message_s sub_prios[] = {
     [McuToJetson_cone_present_tag] = {.priority = SUB_PRIO_DISCARD},
     [McuToJetson_memfault_event_tag] = {.priority = SUB_PRIO_DISCARD},
     [McuToJetson_battery_state_of_health_tag] = {.priority = SUB_PRIO_DISCARD},
+    [McuToJetson_shutdown_tag] = {.priority = SUB_PRIO_TRY_SENDING},
 };
 
 /* ISO-TP addresses + one CAN-FD address */

--- a/west.yml
+++ b/west.yml
@@ -22,10 +22,10 @@ manifest:
       remote: memfault
       revision: 1.9.1
     - name: orb-messages
-      revision: 1ebc148383587f9944bbb628bf4e8cbdea49058f
+      revision: dd255ea4fcab8c0587a3a4892b9d6064c57e1634
       path: modules/orb-messages/public
     - name: priv-orb-messages
-      revision: 7e54d4b0d344eb49552ee62891f55f37f5194e0d
+      revision: 62e024982e458b9a89c530f05b947de4f9d8213d
       path: modules/orb-messages
       groups: [internal]
     - name: plug-and-trust


### PR DESCRIPTION
when battery detected as removed

with `orb-mcu-util`:
```
Shutdown(ShutdownScheduled { shutdown_reason: BatteryRemoved, ms_until_shutdown: Some(7000) })
```

fixes O-2693