### PR TITLE
ir-leds: 1d-tof callback to stop ir-leds

### DIFF
--- a/main_board/src/optics/1d_tof/tof_1d.c
+++ b/main_board/src/optics/1d_tof/tof_1d.c
@@ -30,17 +30,14 @@ BUILD_ASSERT(
 BUILD_ASSERT(INTER_MEASUREMENT_FREQ_HZ > 0,
              "INTER_MEASUREMENT_FREQ_HZ must be greater than 0");
 
+static void (*safety_cb)(bool is_safe) = NULL;
+
 bool
 distance_is_safe(void)
 {
-#ifdef CONFIG_BOARD_DIAMOND_MAIN
-    // fixme: find a way to use 1d tof on diamond
-    return true;
-#else
     long counter = atomic_get(&too_close_counter);
     bool is_safe = counter < TOO_CLOSE_THRESHOLD;
     return is_safe;
-#endif
 }
 
 _Noreturn void
@@ -111,11 +108,15 @@ tof_1d_thread()
         }
         atomic_set(&too_close_counter, counter);
         CRITICAL_SECTION_EXIT(k);
+
+        if (safety_cb) {
+            safety_cb(distance_is_safe());
+        }
     }
 }
 
 int
-tof_1d_init(void)
+tof_1d_init(void (*distance_safe_cb)(bool is_safe))
 {
     if (!device_is_ready(tof_1d_device)) {
         LOG_ERR("VL53L1 not ready!");
@@ -131,6 +132,10 @@ tof_1d_init(void)
     struct sensor_value distance_config = {.val1 = 1 /* short */, .val2 = 0};
     sensor_attr_set(tof_1d_device, SENSOR_CHAN_DISTANCE,
                     SENSOR_ATTR_CONFIGURATION, &distance_config);
+
+    if (distance_safe_cb) {
+        safety_cb = distance_safe_cb;
+    }
 
     // set to autonomous mode by setting sampling frequency / inter measurement
     // period

--- a/main_board/src/optics/1d_tof/tof_1d.h
+++ b/main_board/src/optics/1d_tof/tof_1d.h
@@ -11,9 +11,10 @@ distance_is_safe(void);
 
 /**
  * @brief Initialize 1D ToF sensor
- * @param distance_safe_cb Callback to be called when the safety measure changes
+ * @param distance_unsafe_cb Callback to be called when the measured distance
+ *                            is unsafe for IR-Leds to be turned on.
  * @return RET_SUCCESS on success, RET_ERROR_INVALID_STATE if the ToF sensor
  * isn't ready
  */
 int
-tof_1d_init(void (*distance_safe_cb)(bool is_safe));
+tof_1d_init(void (*distance_unsafe_cb)(void));

--- a/main_board/src/optics/1d_tof/tof_1d.h
+++ b/main_board/src/optics/1d_tof/tof_1d.h
@@ -11,8 +11,9 @@ distance_is_safe(void);
 
 /**
  * @brief Initialize 1D ToF sensor
+ * @param distance_safe_cb Callback to be called when the safety measure changes
  * @return RET_SUCCESS on success, RET_ERROR_INVALID_STATE if the ToF sensor
  * isn't ready
  */
 int
-tof_1d_init(void);
+tof_1d_init(void (*distance_safe_cb)(bool is_safe));

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -114,6 +114,23 @@ optics_safety_circuit_triggered(void)
     return !pvcc_enabled;
 }
 
+// Callback to be called when the safety measure changes
+// This callback is called by the 1D ToF sensor
+// If the distance is not safe, the IR LEDs are turned off
+// by changing the on-time to 0.
+// Any new value being set in the IR camera system will
+// check the distance safety so this function only serves
+// in case the ir-leds are not actuated anymore.
+static void
+distance_is_safe_cb(bool is_safe)
+{
+    if (!is_safe) {
+        // set on-time because it can be changed in any ir-camera
+        // state
+        ir_camera_system_set_on_time_us(0);
+    }
+}
+
 int
 optics_init(const Hardware *hw_version)
 {
@@ -141,7 +158,7 @@ optics_init(const Hardware *hw_version)
         return err_code;
     }
 
-    err_code = tof_1d_init();
+    err_code = tof_1d_init(distance_is_safe_cb);
     if (err_code) {
         ASSERT_SOFT(err_code);
         return err_code;

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -114,21 +114,19 @@ optics_safety_circuit_triggered(void)
     return !pvcc_enabled;
 }
 
-// Callback to be called when the safety measure changes
-// This callback is called by the 1D ToF sensor
-// If the distance is not safe, the IR LEDs are turned off
-// by changing the on-time to 0.
-// Any new value being set in the IR camera system will
-// check the distance safety so this function only serves
-// in case the ir-leds are not actuated anymore.
+/**
+ * This callback is called by the 1D ToF sensor if
+ * the distance is *not* safe for IR-LEDs to be turned on
+ * The on-time is set to 0 because it can be changed in any ir-camera
+ * state.
+ * Any new value being set in the IR camera system will
+ * check the distance safety so this function only serves
+ * in case the ir-leds are not actuated anymore.
+ */
 static void
-distance_is_safe_cb(bool is_safe)
+distance_is_unsafe_cb(void)
 {
-    if (!is_safe) {
-        // set on-time because it can be changed in any ir-camera
-        // state
-        ir_camera_system_set_on_time_us(0);
-    }
+    ir_camera_system_set_on_time_us(0);
 }
 
 int
@@ -158,7 +156,7 @@ optics_init(const Hardware *hw_version)
         return err_code;
     }
 
-    err_code = tof_1d_init(distance_is_safe_cb);
+    err_code = tof_1d_init(distance_is_unsafe_cb);
     if (err_code) {
         ASSERT_SOFT(err_code);
         return err_code;


### PR DESCRIPTION
in case ir-leds are turned on, but not actuated,
use a callback to turn them off on safety
critical conditions.

fixes O-2587