### PR TITLE
rgb-leds: fix apa102 

### DIFF
--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -1,8 +1,8 @@
 #include "front_leds.h"
 #include "app_config.h"
 #include "optics/ir_camera_system/ir_camera_system.h"
-#include "system/version/version.h"
 #include "orb_logs.h"
+#include "system/version/version.h"
 #include "ui/rgb_leds/rgb_leds.h"
 #include <app_assert.h>
 #include <assert.h>
@@ -34,7 +34,7 @@ static const struct device *led_strip = led_strip_w;
 // It's also the minimum amount of time we need to trigger
 // an LED strip update until the next IR LED pulse
 #define LED_STRIP_MAXIMUM_UPDATE_TIME_US 10000
-#else
+#elif defined(CONFIG_BOARD_DIAMOND_MAIN)
 
 static const struct device *const led_strip_apa =
     DEVICE_DT_GET(DT_NODELABEL(front_unit_rgb_leds_apa));
@@ -52,7 +52,7 @@ struct center_ring_leds {
 #if defined(CONFIG_BOARD_PEARL_MAIN)
     struct led_rgb center_leds[NUM_CENTER_LEDS];
     struct led_rgb ring_leds[NUM_RING_LEDS];
-#else
+#elif defined(CONFIG_BOARD_DIAMOND_MAIN)
     // on Diamond, the ring LEDs are the first LEDs
     // connected to the LED strip
     struct led_rgb ring_leds[NUM_RING_LEDS];

--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,7 @@ manifest:
     remote: worldcoin
   projects:
     - name: zephyr
-      revision: 447c41c0729c0cbb4ca9fb6357d592c55c65a7b4
+      revision: 375da85c0598086748cba05b6dbb3642cf7fcbba
       import:
         name-allowlist:
           - cmsis


### PR DESCRIPTION
not all LEDs were actuated due to a bug in the zephyr driver. 
see [zephyr](https://github.com/worldcoin/zephyr/tree/fouge/apa-leds-fix)
fixes O-2678