### PR TITLE
mirror: diamond: invert motors and direction

### DIFF
--- a/main_board/src/optics/mirror/mirror.c
+++ b/main_board/src/optics/mirror/mirror.c
@@ -1308,6 +1308,11 @@ mirror_init(void)
         LOG_INF("Motion controller SPI ready");
     }
 
+#if defined(CONFIG_BOARD_DIAMOND_MAIN)
+    // write TMC5041_REG_GCONF to 0x300 to invert motor direction (bit 8 & 9)
+    motor_controller_spi_write(spi_bus_controller, TMC5041_REG_GCONF, 0x300);
+#endif
+
     read_value =
         motor_controller_spi_read(spi_bus_controller, TMC5041_REG_GCONF);
     LOG_INF("GCONF: 0x%08x", read_value);

--- a/main_board/src/optics/mirror/mirror.h
+++ b/main_board/src/optics/mirror/mirror.h
@@ -17,7 +17,11 @@
  * movement. (If the current theta angle is different from 90° you also see a
  * small up/down movement).
  */
+#if defined(CONFIG_BOARD_PEARL_MAIN)
 typedef enum { MOTOR_THETA_ANGLE = 0, MOTOR_PHI_ANGLE, MOTORS_COUNT } motor_t;
+#elif defined(CONFIG_BOARD_DIAMOND_MAIN)
+typedef enum { MOTOR_PHI_ANGLE = 0, MOTOR_THETA_ANGLE, MOTORS_COUNT } motor_t;
+#endif
 
 #if defined(CONFIG_BOARD_PEARL_MAIN)
 #define MIRROR_ANGLE_PHI_MIN_MILLIDEGREES (45000 - 9500)


### PR DESCRIPTION
- axis: The background is assembly and supply chain driven: we need to make sure that an assembly worker cannot plug in the steppers the wrong way around. Connectors are located on the main board so that the cables are too short if connected incorrectly.
- direction: motor behavior changed with new motors on diamond. issue is still undocumented due to lack of datasheet from the manufacturer, but use this as a workaround for now.

fixes O-2723