### PR TITLE
semaphores: declare them as `static`

### DIFF
--- a/lib/dfu/dfu.c
+++ b/lib/dfu/dfu.c
@@ -77,8 +77,8 @@ static void (*dfu_block_process_cb)(void *ctx, int err) = NULL;
 
 // 1 producer and 1 consumer sharing dfu_state
 // we need two semaphores
-K_SEM_DEFINE(sem_dfu_free_space, 1, 1);
-K_SEM_DEFINE(sem_dfu_full, 0, 1);
+static K_SEM_DEFINE(sem_dfu_free_space, 1, 1);
+static K_SEM_DEFINE(sem_dfu_full, 0, 1);
 
 int
 dfu_load(uint32_t current_block_number, uint32_t block_count,

--- a/main_board/src/optics/ir_camera_system/ir_camera_system_hw.c
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system_hw.c
@@ -350,7 +350,7 @@ evaluate_mirror_sweep_polynomials(uint32_t frame_no)
 }
 
 #ifdef HIL_TEST
-K_SEM_DEFINE(camera_sweep_sem, 0, 1);
+static K_SEM_DEFINE(camera_sweep_sem, 0, 1);
 #endif
 
 static void

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -94,7 +94,7 @@ static const struct gpio_dt_spec usb_hub_reset_gpio_spec =
     GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), usb_hub_reset_gpios);
 #endif
 
-K_SEM_DEFINE(sem_reboot, 0, 1);
+static K_SEM_DEFINE(sem_reboot, 0, 1);
 static atomic_t reboot_delay_s = ATOMIC_INIT(0);
 static k_tid_t reboot_tid = NULL;
 static struct gpio_callback shutdown_cb_data;

--- a/main_board/src/pubsub/pubsub.c
+++ b/main_board/src/pubsub/pubsub.c
@@ -25,7 +25,7 @@ BUILD_ASSERT(
 #endif
 #endif
 
-K_SEM_DEFINE(pub_buffers_sem, 1, 1);
+static K_SEM_DEFINE(pub_buffers_sem, 1, 1);
 
 static K_THREAD_STACK_DEFINE(pub_stored_stack_area,
                              THREAD_STACK_SIZE_PUB_STORED);

--- a/main_board/src/pubsub/pubsub_tests.c
+++ b/main_board/src/pubsub/pubsub_tests.c
@@ -11,7 +11,7 @@
 LOG_MODULE_REGISTER(pubsub_test);
 
 static uint32_t mcu_to_jetson_payloads = 0;
-K_SEM_DEFINE(pub_buffers_sem, 1, 1);
+static K_SEM_DEFINE(pub_buffers_sem, 1, 1);
 
 int
 subscribe_add(uint32_t remote_addr)


### PR DESCRIPTION
isolate in the compilation unit to prevent
any mistake with incorrect cross-referencing