### PR TITLE
rgb-leds: remove error on mutex locked

### DIFF
--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -511,9 +511,10 @@ front_leds_set_center_leds_sequence_argb32(const uint8_t *bytes, uint32_t size)
         }
         ret = RET_SUCCESS; // overwrite the error if LEDs are already set to
                            // expected values
-    } else {
+    } else if (ret != RET_ERROR_INTERNAL) {
         ASSERT_SOFT(ret);
     }
+
     return ret;
 }
 
@@ -535,9 +536,10 @@ front_leds_set_center_leds_sequence_rgb24(const uint8_t *bytes, uint32_t size)
         }
         ret = RET_SUCCESS; // overwrite the error if LEDs are already set to
                            // expected values
-    } else {
+    } else if (ret != RET_ERROR_INTERNAL) {
         ASSERT_SOFT(ret);
     }
+
     return ret;
 }
 
@@ -559,9 +561,10 @@ front_leds_set_ring_leds_sequence_argb32(const uint8_t *bytes, uint32_t size)
         }
         ret = RET_SUCCESS; // overwrite the error if LEDs are already set to
                            // expected values
-    } else {
+    } else if (ret != RET_ERROR_INTERNAL) {
         ASSERT_SOFT(ret);
     }
+
     return ret;
 }
 
@@ -583,9 +586,10 @@ front_leds_set_ring_leds_sequence_rgb24(const uint8_t *bytes, uint32_t size)
         }
         ret = RET_SUCCESS; // overwrite the error if LEDs are already set to
                            // expected values
-    } else {
+    } else if (ret != RET_ERROR_INTERNAL) {
         ASSERT_SOFT(ret);
     }
+
     return ret;
 }
 

--- a/main_board/src/ui/rgb_leds/rgb_leds.c
+++ b/main_board/src/ui/rgb_leds/rgb_leds.c
@@ -40,7 +40,6 @@ rgb_leds_set_leds_sequence(const uint8_t *input_bytes, size_t input_size_bytes,
     if (write_mutex != NULL) {
         int ret = k_mutex_lock(write_mutex, K_NO_WAIT);
         if (ret != 0) {
-            LOG_ERR("set_leds_sequence: failed to lock mutex: %d", ret);
             return RET_ERROR_INTERNAL;
         }
     }


### PR DESCRIPTION
don't assert to log error on mutex locked
because it's going to happen and it's fine.