### PR TITLE
tests: ir-led timeout

### DIFF
--- a/main_board/src/optics/ir_camera_system/ir_camera_system.h
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.h
@@ -8,8 +8,13 @@
     (STRUCT_MEMBER_SIZE_BYTES(IREyeCameraFocusSweepLensValues, focus_values) / \
      (sizeof(uint16_t)))
 
+#ifdef CONFIG_ZTEST
+// in tests we don't want to wait for too long
+#define IR_LED_AUTO_OFF_TIMEOUT_S (6) // ztest - 6 seconds
+#else
 // automatically turn off IR LEDs after 60 seconds without any activity
 #define IR_LED_AUTO_OFF_TIMEOUT_S (60)
+#endif
 
 /**
  * @brief Enable the IR eye camera


### PR DESCRIPTION
test that ir leds are turned off
after 6 seconds (timeout in tests)

```
START - test_ir_led_timeout
[00:01:29.455,000] <wrn> ir_camera_system: Turning off IR LEDs after 6s of inactivity
PASS - test_ir_led_timeout in 6.108 seconds
```

fixes O-2750
