### PR TITLE
rgb-leds: control the dimming value of the RGB LEDs

### DIFF
--- a/main_board/src/ui/rgb_leds/cone_leds/cone_leds.c
+++ b/main_board/src/ui/rgb_leds/cone_leds/cone_leds.c
@@ -83,11 +83,19 @@ cone_leds_set_pattern(ConeLEDsPattern_ConeRgbLedPattern pattern,
 {
     ret_code_t ret = RET_SUCCESS;
 
+    if (color == NULL) {
+        return RET_ERROR_INVALID_PARAM;
+    }
+
+    if (color->dimming == 0 || color->dimming > RGB_BRIGHTNESS_MAX) {
+        color->dimming = RGB_BRIGHTNESS_MAX;
+    }
+
     CRITICAL_SECTION_ENTER(k);
     global_pattern = pattern;
     global_color = (struct led_rgb){
 #ifdef CONFIG_LED_STRIP_RGB_SCRATCH
-        .scratch = RGB_BRIGHTNESS_MAX,
+        .scratch = color->dimming,
 #endif
         .r = color->red,
         .g = color->green,

--- a/main_board/src/ui/rgb_leds/rgb_leds.h
+++ b/main_board/src/ui/rgb_leds/rgb_leds.h
@@ -74,12 +74,12 @@
 
 #define RGB_WHITE_BUTTON_PRESS                                                 \
     {                                                                          \
-        20, 20, 20                                                             \
+        31, 20, 20, 20                                                         \
     }
 
 #define RGB_WHITE_SHUTDOWN                                                     \
     {                                                                          \
-        MINIMUM_WHITE_BRIGHTNESS, MINIMUM_WHITE_BRIGHTNESS,                    \
+        31, MINIMUM_WHITE_BRIGHTNESS, MINIMUM_WHITE_BRIGHTNESS,                \
             MINIMUM_WHITE_BRIGHTNESS                                           \
     }
 

--- a/west.yml
+++ b/west.yml
@@ -22,10 +22,10 @@ manifest:
       remote: memfault
       revision: 1.9.1
     - name: orb-messages
-      revision: 787ab78581b705af0946bcfe3a0453b64af2193f
+      revision: ac7246ffdb7b03def49b92a05f1e8ad578bc56ab
       path: modules/orb-messages/public
     - name: priv-orb-messages
-      revision: 1879a2ff0ea9904ba5eecad020ea7b7971e3c8d4
+      revision: 86fff1d80b7c762d7c31bf7b8393af0f1d5ddb6c
       path: modules/orb-messages
       groups: [internal]
     - name: plug-and-trust


### PR DESCRIPTION
When supported by the hardware, the RGB LEDs can be dimmed using a specific byte sent to the LED. The byte is a value between 0 and 31, where 0 is the minimum brightness and 31 is the maximum. So far, we defaulted the value to 31.

See https://github.com/worldcoin/orb-control-api-client/pull/164