### PR TITLE
ci: add pre-commit checks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,15 @@
+name: Format
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --config utils/format/pre-commit-config.yaml

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds_tests.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds_tests.c
@@ -2,8 +2,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
-#include "ui/rgb_leds/rgb_leds.h"
 #include "orb_logs.h"
+#include "ui/rgb_leds/rgb_leds.h"
 
 LOG_MODULE_REGISTER(user_leds_test);
 


### PR DESCRIPTION
enforce usage of formatters & linters configured with the pre-commit config file