### PR TITLE
fix(can): CAN device to always seek recovery

### DIFF
--- a/lib/can_messaging/Kconfig
+++ b/lib/can_messaging/Kconfig
@@ -60,4 +60,8 @@ config CAN_ISOTP_MAX_SIZE_BYTES
     help
         "An ISO-TP message can contain up to 4096 bytes but we might want to cap the value depending on application's constraints"
 
+config ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE
+    int "CAN TX queue size"
+    default 16
+
 endif

--- a/lib/can_messaging/Kconfig
+++ b/lib/can_messaging/Kconfig
@@ -12,6 +12,14 @@ config CAN_ADDRESS_DEFAULT_REMOTE
     hex "Default CAN address to send data to"
     default 0x80
 
+config ORB_LIB_THREAD_PRIORITY_CANBUS_MONITOR
+    int "CAN bus monitoring thread priority"
+    default 5
+
+config ORB_LIB_THREAD_STACK_SIZE_CANBUS_MONITOR
+    int "Stack size for CAN monitoring thread"
+    default 1500
+
 config ORB_LIB_THREAD_PRIORITY_CANBUS_RX
     int "CAN bus RX thread priority"
     default 5

--- a/lib/can_messaging/canbus_tx.c
+++ b/lib/can_messaging/canbus_tx.c
@@ -71,11 +71,7 @@ send(const char *data, size_t len,
         // CAN will recover when 3v3 back on
         LOG_ERR("err: %i", ret);
         if (ret == -ENETUNREACH) {
-            // CAN bus in off state
-            if (can_dev != NULL) {
-                ret = can_recover(can_dev, K_MSEC(2000));
-                ASSERT_HARD(ret);
-            }
+            can_messaging_resume();
         }
     }
 
@@ -141,6 +137,7 @@ can_messaging_async_tx(const can_message_t *message)
     enum can_state can_state;
     can_get_state(can_dev, &can_state, &can_err);
     if (can_state == CAN_STATE_BUS_OFF || can_state == CAN_STATE_STOPPED) {
+        can_messaging_resume();
         return RET_ERROR_INVALID_STATE;
     }
 

--- a/lib/can_messaging/canbus_tx_isotp.c
+++ b/lib/can_messaging/canbus_tx_isotp.c
@@ -26,11 +26,11 @@ BUILD_ASSERT(sizeof(can_message_t) % QUEUE_ALIGN == 0,
 
 // Message queue to send messages
 K_MSGQ_DEFINE(isotp_tx_msg_queue, sizeof(can_message_t),
-              CONFIG_ORB_LIB_CANBUS_TX_QUEUE_SIZE, QUEUE_ALIGN);
+              CONFIG_ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE, QUEUE_ALIGN);
 
 static struct k_heap can_tx_isotp_memory_heap;
 static char __aligned(4)
-    can_tx_isotp_memory_heap_buffer[CONFIG_ORB_LIB_CANBUS_TX_QUEUE_SIZE *
+    can_tx_isotp_memory_heap_buffer[CONFIG_ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE *
                                     CONFIG_CAN_ISOTP_MAX_SIZE_BYTES];
 
 static K_SEM_DEFINE(tx_sem, 1, 1);


### PR DESCRIPTION
with the introduction of a new thread, the CAN state is polled regularly to ensure that the device will always seek recovery. The callback feature used in the past doesn't seem to be reliable.

fixes ORBP-185