### PR TITLE
fix(can): decrease ISO-TP TX queue size

### DIFF
--- a/lib/can_messaging/Kconfig
+++ b/lib/can_messaging/Kconfig
@@ -60,4 +60,8 @@ config CAN_ISOTP_MAX_SIZE_BYTES
     help
         "An ISO-TP message can contain up to 4096 bytes but we might want to cap the value depending on application's constraints"
 
+config ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE
+    int "CAN TX queue size"
+    default 16
+
 endif

--- a/lib/can_messaging/canbus_tx_isotp.c
+++ b/lib/can_messaging/canbus_tx_isotp.c
@@ -26,11 +26,11 @@ BUILD_ASSERT(sizeof(can_message_t) % QUEUE_ALIGN == 0,
 
 // Message queue to send messages
 K_MSGQ_DEFINE(isotp_tx_msg_queue, sizeof(can_message_t),
-              CONFIG_ORB_LIB_CANBUS_TX_QUEUE_SIZE, QUEUE_ALIGN);
+              CONFIG_ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE, QUEUE_ALIGN);
 
 static struct k_heap can_tx_isotp_memory_heap;
 static char __aligned(4)
-    can_tx_isotp_memory_heap_buffer[CONFIG_ORB_LIB_CANBUS_TX_QUEUE_SIZE *
+    can_tx_isotp_memory_heap_buffer[CONFIG_ORB_LIB_CAN_ISOTP_TX_QUEUE_SIZE *
                                     CONFIG_CAN_ISOTP_MAX_SIZE_BYTES];
 
 static K_SEM_DEFINE(tx_sem, 1, 1);


### PR DESCRIPTION
decreases RAM usage
ISO-TP is mostly used with request/response
pattern (max 1 ack + 1 data for each received request);
broadcast messages are sent over CAN-FD.
A maximum of 8 rx contexts are allowed
(never actually reached), so 16 tx messages
should suffice.