### PR TITLE
chore(env): update python and dependencies

### DIFF
--- a/utils/env/entrypoint.sh
+++ b/utils/env/entrypoint.sh
@@ -1,8 +1,14 @@
 # Load the miniconda environment
 # Can be used as `environment file` in CLion when setting up the toolchain
 
+# reset PATH variable
+export PATH=$(getconf PATH)
+
 # load env based on initial shell
 if [ -n "${ZSH_NAME:-}" ]; then
+    # see `man zsh`
+    . "$HOME"/.zshenv
+    . /etc/zshrc
     . "$HOME"/.zshrc
 elif [ -n "${BASH:-}" ]; then
     . "$HOME"/.bashrc

--- a/utils/env/environment.yml
+++ b/utils/env/environment.yml
@@ -1,7 +1,7 @@
 name: worldcoin
 dependencies:
   - make
-  - python=3.9
+  - python=3.13
   - pyserial
   - ccache
   - conda-forge::protobuf
@@ -9,7 +9,7 @@ dependencies:
   - pthread-stubs
   - gperf
   - clang-format
-  - pre-commit=3.5.0
+  - pre-commit
   - conda-forge::libusb
   - gnupg
   - pip
@@ -19,7 +19,6 @@ dependencies:
       - pyocd
       - crc16
       - puncover
-      - anytree==2.8.0 # rom_report fails with 2.9.0
       - identify>=2.5.32
       - mflt-compact-log
       - -r ../test/requirements.txt

--- a/utils/test/requirements.txt
+++ b/utils/test/requirements.txt
@@ -1,4 +1,4 @@
-fabric2==3.0.0
-matplotlib==3.7.1
+fabric2==3.2
+matplotlib==3.9
 ppk2-api==0.9.2
-pyftdi==0.54.0
+pyftdi==0.55


### PR DESCRIPTION
python 3.13 for zephyr 4 (requires at least python 3.10)
fix entrypoint.sh file used by clion. reset PATH before sourcing env files & conda env
