### PR TITLE
chore(zephyr): proper python3 calls

### DIFF
--- a/main_board/CMakeLists.txt
+++ b/main_board/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SINE_TABLE_LENGTH 150)
 add_compile_definitions(SINE_TABLE_LENGTH=${SINE_TABLE_LENGTH})
 set(SINE_LUT_SRC_FILE ${CMAKE_BINARY_DIR}/zephyr/sine_lut.c)
 add_custom_command(OUTPUT ${SINE_LUT_SRC_FILE}
-    COMMAND python3 ${PROJECT_DIR}/utils/math/generate_half_sine.py ${SINE_TABLE_LENGTH} > ${SINE_LUT_SRC_FILE})
+    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_DIR}/utils/math/generate_half_sine.py ${SINE_TABLE_LENGTH} > ${SINE_LUT_SRC_FILE})
 
 set(SOURCES_FILES)
 # common source files

--- a/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/CMakeLists.txt
+++ b/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/CMakeLists.txt
@@ -26,6 +26,6 @@ target_sources(testbinary PRIVATE
 
 add_custom_command(
     OUTPUT main.c
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/jinja_expand.py ${CMAKE_CURRENT_SOURCE_DIR} template_main.c main.c
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/jinja_expand.py ${CMAKE_CURRENT_SOURCE_DIR} template_main.c main.c
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jinja_expand.py ${CMAKE_CURRENT_SOURCE_DIR}/template_main.c
 )

--- a/utils/math/generate_half_sine.py
+++ b/utils/math/generate_half_sine.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import math
 import sys
 


### PR DESCRIPTION
use `${PYTHON_EXECUTABLE}` to ensure the Python executable loaded by CMake/west is used
and shebang for python script `#!/usr/bin/env python3`