### PR TITLE
fix(west): project path is now `orb/`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/zephyr_build.yml
     with:
       board: pearl_main
-      app_path: orb/public/main_board
+      app_path: orb/main_board
     secrets:
       gh_token: ${{ secrets.GIT_HUB_TOKEN }}
 
@@ -21,6 +21,6 @@ jobs:
     uses: ./.github/workflows/zephyr_build.yml
     with:
       board: diamond_main
-      app_path: orb/public/main_board
+      app_path: orb/main_board
     secrets:
       gh_token: ${{ secrets.GIT_HUB_TOKEN }}

--- a/.github/workflows/twister_native.yml
+++ b/.github/workflows/twister_native.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
-          path: "${{ github.job }}/orb/public"
+          path: "${{ github.job }}/orb"
       - name: Initialize West repo
         run: |
           cd ${{ github.job }}
           git config --global --add url."https://wc-cicd:${{ secrets.GIT_HUB_TOKEN }}@github.com/worldcoin/".insteadOf "git@github.com:worldcoin/"
-          cd orb && west init -l --mf public/west.yml . || echo "Ignoring west init error $?" # might be already initialized
+          cd orb && west init -l --mf west.yml . || echo "Ignoring west init error $?" # might be already initialized
           west update --narrow --fetch-opt=--depth=1
       - name: Twister native POSIX 64
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Twister unit tests
         run: |
           cd ${{ github.job }}
-          if ! ./zephyr/scripts/twister -T orb/public/main_board -vv -c -p unit_testing; then
+          if ! ./zephyr/scripts/twister -T orb/main_board -vv -c -p unit_testing; then
             find twister-out/ \( -name 'build.log' -o -name 'handler.log' -o -name 'device.log' \) -exec cat {} \;
             false
           fi

--- a/.github/workflows/zephyr_build.yml
+++ b/.github/workflows/zephyr_build.yml
@@ -24,16 +24,31 @@ jobs:
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
-          path: "${{ github.job }}/orb/public"
+          path: "${{ github.job }}/orb"
       - name: Initialize West repo
         run: |
           cd ${{ github.job }}
           git config --global --add url."https://wc-cicd:${{ secrets.gh_token }}@github.com/worldcoin/".insteadOf "git@github.com:worldcoin/"
-          cd orb && west init -l --mf public/west.yml . || echo "Ignoring west init error $?" # might be already initialized
+          cd orb && west init -l --mf west.yml . || echo "Ignoring west init error $?" # might be already initialized
           west update --narrow --fetch-opt=--depth=1
       - name: Generate temporary signing keys locally
-        run: cd ${{ github.job }}/orb/public/utils/ota/ && ./generate_dev_keys
+        run: cd ${{ github.job }}/orb/utils/ota/ && ./generate_dev_keys
       - name: Build app
-        run: cd ${{ github.job }} && west build ${APP_PATH} -d ${APP_PATH}/build -b ${BOARD} -p -- -DCMAKE_BUILD_TYPE="Release" -DEXTRA_COMPILE_FLAGS=-Werror -DBUILD_FROM_CI=1
+        run: |
+          cd ${{ github.job }}
+          PROJ_DIR=$(dirname $(west manifest --path))
+          west build ${APP_PATH} -d ${APP_PATH}/build -b ${BOARD} -p -- \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DEXTRA_COMPILE_FLAGS=-Werror \
+          -DBUILD_FROM_CI=1 \
+          -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"${PROJ_DIR}/utils/ota/root-ec-p256.pem\" \
+          -DCONFIG_MCUBOOT_ENCRYPTION_KEY_FILE=\"${PROJ_DIR}/utils/ota/enc-ec256-pub.pem\"
       - name: Build bootloader
-        run: cd ${{ github.job }} && west build orb/public/bootloader -d orb/public/bootloader/build -b ${BOARD} -p -- -DCMAKE_BUILD_TYPE="Release" -DBUILD_FROM_CI=1
+        run: |
+          cd ${{ github.job }}
+          PROJ_DIR=$(dirname $(west manifest --path))
+          ENC_KEY_FILE="${PROJ_DIR}/utils/ota/enc-ec256-pub.pem"
+          west build orb/bootloader -d orb/bootloader/build -b ${BOARD} -p -- \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DBUILD_FROM_CI=1 \
+          -DCONFIG_BOOT_SIGNATURE_KEY_FILE=\"${PROJ_DIR}/utils/ota/root-ec-p256.pem\"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ the [conda environment](utils/env/environment.yml).
 Configure `pre-commit` using the config in the repo:
 
 ```shell
-cd "$REPO_DIR"/orb/public
+cd "$WEST_TOPDIR"/orb
 pre-commit install -c utils/format/pre-commit-config.yaml --hook-type commit-msg
 ```
 
@@ -24,13 +24,13 @@ pre-commit install -c utils/format/pre-commit-config.yaml --hook-type commit-msg
 Manually:
 
 ```shell
-cd "$REPO_DIR"/orb/public && pre-commit run --all-files --config utils/format/pre-commit-config.yaml
+cd "$WEST_TOPDIR"/orb && pre-commit run --all-files --config utils/format/pre-commit-config.yaml
 ```
 
 Using Docker:
 
 ```shell
-cd "$REPO_DIR"/orb/public/utils/docker
+cd utils/docker
 make format
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ enumerated in the [west.yml](west.yml) file.
 2. Create an empty directory where the projects and dependencies will be located.
 
    ```shell
-   export REPO_DIR=$HOME/firmware # or any other directory
-   mkdir "$REPO_DIR"
+   export WEST_TOPDIR=$HOME/firmware # or any other directory
+   mkdir "$WEST_TOPDIR"
    ```
 
 3. Clone the manifest repository using west.
 
    ```shell
-   cd "$REPO_DIR"
+   cd "$WEST_TOPDIR"
    west init -m <repo-url.git> --mr main
    ```
 
@@ -65,7 +65,7 @@ enumerated in the [west.yml](west.yml) file.
 
 5. If you prefer to use Docker, you can use the provided [Dockerfile](utils/docker/Dockerfile).
    ```shell
-    cd "$REPO_DIR"/orb/public/utils/docker
+    cd utils/docker
     make build
     make shell
    ```
@@ -81,11 +81,11 @@ the [Zephyr getting started guide](https://docs.zephyrproject.org/latest/getting
      for [installing dependencies](https://docs.zephyrproject.org/latest/getting_started/index.html#install-dependencies).
      - Then:
        ```shell
-       pip3 install -r "$REPO_DIR"/zephyr/scripts/requirements.txt
+       pip3 install -r "$WEST_TOPDIR"/zephyr/scripts/requirements.txt
        ```
    - Or install the Conda environment provided [here](utils/env/environment.yml).
      ```shell
-     conda env create -f orb/public/utils/env/environment.yml
+     conda env create -f orb/utils/env/environment.yml
      conda activate worldcoin
      ```
 
@@ -171,7 +171,7 @@ the [Zephyr getting started guide](https://docs.zephyrproject.org/latest/getting
 10. Export CMake packages.
 
 ```shell
-cd "$REPO_DIR"
+cd "$WEST_TOPDIR"
 west zephyr-export
 ```
 
@@ -207,7 +207,7 @@ Print out the bootloader and main MCU application logs using:
 
 ```shell
 # replace /dev/ttyxxx with your UART device
-python "$REPO_DIR"/orb/public/utils/debug/uart_dump.py -p /dev/ttyxxx -b 115200
+python "$WEST_TOPDIR"/orb/utils/debug/uart_dump.py -p /dev/ttyxxx -b 115200
 ```
 
 ## Contributing

--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -7,9 +7,9 @@ First, follow the instructions in the [top-level README.md](../README.md).
 ## Compiling and Flashing
 
 If you don't have development keys already created locally, then run
-`./generate_dev_keys` while in the directory `"$REPO_DIR"/orb/public/utils/ota/`.
+`./generate_dev_keys` while in the directory `utils/ota/`.
 
-Make sure you are in `"$REPO_DIR"/orb/public/bootloader/` directory.
+Make sure you are in `"$WEST_TOPDIR"/orb/bootloader/` directory.
 Compile the bootloader for the main microcontroller:
 
 ```shell

--- a/bootloader/prj.conf
+++ b/bootloader/prj.conf
@@ -11,7 +11,8 @@ CONFIG_GPIO=y
 # signature
 CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
 # path to signature key; must be relative to West top dir
-CONFIG_BOOT_SIGNATURE_KEY_FILE="orb/public/utils/ota/root-ec-p256.pem"
+# dev key, redefined for production
+CONFIG_BOOT_SIGNATURE_KEY_FILE="orb/utils/ota/root-ec-p256.pem"
 
 # encryption
 CONFIG_BOOT_SWAP_SAVE_ENCTLV=n # do not store encrypted TLV

--- a/main_board/README.md
+++ b/main_board/README.md
@@ -10,7 +10,7 @@ Once downloaded, `west` will check out this repository in the `orb` directory wi
 you want to work on the repo, make sure to check out the `main` branch and branch from there.
 
 ```shell
-cd "$REPO_DIR"/orb/public/
+cd orb
 git remote add origin <repo-url.git>
 git fetch
 git checkout main
@@ -29,14 +29,14 @@ Let's build and run the application, you have several options:
 > 💡 Important notes:
 >
 > - Firmware images are signed and encrypted. If you don't have development keys already created locally, then run
->   `./generate_dev_keys` while in the directory `"$REPO_DIR"/orb/public/utils/ota/`.
+>   `./generate_dev_keys` while in the directory `utils/ota/`.
 > - Make sure to have the [bootloader built and flashed](../../bootloader/README.md) with the keys _before_ flashing the application.
 > - If you want to use the one-slot configuration (`-DDTC_OVERLAY_FILE=one_slot.overlay`) then the bootloader must have
 >   been built with this option as well.
 
 #### With Makefile
 
-- Go to `${REPO_DIR}/orb/public/utils/docker`.
+- Go to `utils/docker`.
 - Run `make help` to see all options
 
 To Build: `make main_board-build`
@@ -45,7 +45,7 @@ To Flash: `make mcu-flash`
 
 #### Manually
 
-Make sure you are in `"$REPO_DIR"/orb/public/main_board` directory. Compile the app:
+Make sure you are in `"$WEST_TOPDIR"/orb/main_board` directory. Compile the app:
 
 ```shell
 # 'west build' defaults to pearl_main and Debug build
@@ -116,7 +116,7 @@ Twister can be used to compile and flash test configurations defined in `testcas
 with `pyocd` runner:
 
 ```shell
-twister -vv -T . -A ./../../boards/ -p pearl_main -c --test orb/public/main_board/orb.hil \
+twister -vv -T . -A ./../../boards/ -p pearl_main -c --test orb/main_board/orb.hil \
 --device-serial /dev/ttyXXX --device-testing --west-flash="-i=<UNIQUE_ID>"
 ```
 

--- a/main_board/prj.conf
+++ b/main_board/prj.conf
@@ -111,8 +111,9 @@ CONFIG_DYNAMIC_INTERRUPTS=y
 # Enable Zephyr application to be booted by MCUboot
 CONFIG_BOOTLOADER_MCUBOOT=y
 # Path to signature file. Must be absolute or relative to West top dir
-CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="orb/public/utils/ota/root-ec-p256.pem"
-CONFIG_MCUBOOT_ENCRYPTION_KEY_FILE="orb/public/utils/ota/enc-ec256-pub.pem"
+# dev key, redefined for production
+CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="orb/utils/ota/root-ec-p256.pem"
+CONFIG_MCUBOOT_ENCRYPTION_KEY_FILE="orb/utils/ota/enc-ec256-pub.pem"
 CONFIG_MCUBOOT_BOOTUTIL_LIB=y
 CONFIG_BOOT_BANNER=n
 

--- a/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/CMakeLists.txt
+++ b/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/CMakeLists.txt
@@ -9,8 +9,8 @@ endif ()
 
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(ORB_DIR ${ZEPHYR_BASE}/../orb/public)
-set(APP_DIR ${ORB_DIR}/main_board)
+get_filename_component(APP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE)
+get_filename_component(ORB_DIR "${APP_DIR}/.." ABSOLUTE)
 
 target_include_directories(testbinary PRIVATE
     mock_include

--- a/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_timer_settings/CMakeLists.txt
+++ b/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_timer_settings/CMakeLists.txt
@@ -9,8 +9,8 @@ endif ()
 
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(ORB_DIR ${ZEPHYR_BASE}/../orb/public)
-set(APP_DIR ${ORB_DIR}/main_board)
+get_filename_component(APP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE)
+get_filename_component(ORB_DIR "${APP_DIR}/.." ABSOLUTE)
 
 target_include_directories(testbinary PRIVATE
     mock_include

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,6 +1,10 @@
 # Use DOCKER_TAG if passed in from command line
 DOCKER_IMAGE_NAME := orb-mcu-firmware-builder$(if $(DOCKER_TAG),:$(DOCKER_TAG),:local)
 
+# Get the project root directory
+WEST_YAML := $(shell west manifest --path)
+PROJ_DIR := $(dirname $(WEST_YAML))
+
 ifneq ($(filter help all build,$(MAKECMDGOALS)),)
 
 .PHONY: help
@@ -24,8 +28,8 @@ help:
 	@:$(info )
 	@:$(info Examples:)
 	@:$(info )
-	@:$(info make main_mcu-build REPO_DIR=/home/$USER/firmware)
-	@:$(info make main_mcu-tests REPO_DIR=/home/$USER/firmware)
+	@:$(info make main_mcu-build WEST_TOPDIR=/home/$USER/firmware)
+	@:$(info make main_mcu-tests WEST_TOPDIR=/home/$USER/firmware)
 
 .PHONY: all build
 all build: .docker_image_built
@@ -36,8 +40,8 @@ all build: .docker_image_built
 
 else
 
-ifndef REPO_DIR
-REPO_DIR := $(shell west topdir)
+ifndef WEST_TOPDIR
+WEST_TOPDIR := $(shell west topdir)
 endif
 
 ifdef BOARD
@@ -64,18 +68,18 @@ shell:
 
 mcu-build:
 	$(DOCKER_CMD) /bin/bash -c -- \
-		'cd $(REPO_DIR)/orb/public/main_board && west build $(BOARD_CMD)'
+		'cd $(PROJ_DIR)/main_board && west build $(BOARD_CMD)'
 
 mcu-flash:
 	$(DOCKER_CMD) /bin/bash -c -- \
-		'cd $(REPO_DIR)/orb/public/main_board && west build $(BOARD_CMD) && su-exec root west flash'
+		'cd $(PROJ_DIR)/main_board && west build $(BOARD_CMD) && su-exec root west flash'
 
 mcu-clean:
-	cd $(REPO_DIR)/orb/main_board && rm -rf build
+	cd $(WEST_TOPDIR)/orb/main_board && rm -rf build
 
 mcu-tests:
 	$(DOCKER_CMD) /bin/bash -c -- \
-		'source $(REPO_DIR)/zephyr/zephyr-env.sh && cd $(REPO_DIR)/orb/main_board && twister -T . -vv -c -p native_posix_64'
+		'source $(WEST_TOPDIR)/zephyr/zephyr-env.sh && cd $(PROJ_DIR)/main_board && twister -T . -vv -c -p native_posix_64'
 
 .PHONY: format
 format:


### PR DESCRIPTION
don't use `orb/public`

was not causing issues so far but zephyr_module.py changed and isn't able to find the project repo for zephyr.meta generation

it's important to note that this is only when the repo is used alone, without it's `private` counterpart.