### PR TITLE
chore(env): Update fast forward pipeline token

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -15,13 +15,10 @@ jobs:
       issues: write
 
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           merge: true
           debug: true

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -15,6 +15,11 @@ jobs:
       issues: write
 
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
         with:


### PR DESCRIPTION
Trying to pass GITHUB_SECRET directly to the fast forward pipeline, as this value is taken from env variables in sequoia-pgp/fast-forward@v1 action

Signed-off-by: [Michał Leszczyński] <michal.leszczynski@toolsforhumanity.com>