### PR TITLE
chore(env): Update fast forward pipeline token

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           merge: true
           debug: true


### PR DESCRIPTION
Trying to pass GITHUB_SECRET directly to the fast forward pipeline, as this value is taken from env variables in sequoia-pgp/fast-forward@v1 action

Signed-off-by: [Michał Leszczyński] [michal.leszczynski@toolsforhumanity.com](mailto:michal.leszczynski@toolsforhumanity.com)