### PR TITLE
fix(ci): do not build new docker image on Makefile change

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -3,7 +3,6 @@ on:
   push:
     paths:
       - utils/docker/Dockerfile
-      - utils/docker/Makefile
       - .github/workflows/docker_build.yml
 jobs:
   build_and_publish:


### PR DESCRIPTION
docker is mainly used in ci
makefile is used locally, for dev purposes