### PR TITLE
chore(env): Update fast forward pipeline token

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           merge: true
           debug: true
@@ -27,3 +25,4 @@ jobs:
           # never post a comment.  (In all cases the information is
           # still available in the step's summary.)
           comment: on-error
+          github_token: ${{ github.GITHUB_TOKEN }}


### PR DESCRIPTION
Trying to pass GITHUB_SECRET directly to the fast forward pipeline as github_token

Signed-off-by: [Michał Leszczyński] [michal.leszczynski@toolsforhumanity.com](mailto:michal.leszczynski@toolsforhumanity.com)