### PR TITLE
chore(env): Update fast forward pipeline token

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -25,4 +25,4 @@ jobs:
           # never post a comment.  (In all cases the information is
           # still available in the step's summary.)
           comment: on-error
-          github_token: ${{ github.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trying to pass GITHUB_SECRET directly to the fast forward pipeline as github_token - fix variable reference

Signed-off-by: [Michał Leszczyński] [michal.leszczynski@toolsforhumanity.com](mailto:michal.leszczynski@toolsforhumanity.com)