### PR TITLE
feat(reboot reason): reason published on mcu-util requested reboot

### DIFF
--- a/main_board/config/memfault_reboot_reason_user_config.def
+++ b/main_board/config/memfault_reboot_reason_user_config.def
@@ -1,3 +1,4 @@
 // Defines "unexpected" reboots
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(BatteryRemoved)
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HeartbeatFromJetsonTimeout)
+MEMFAULT_EXPECTED_REBOOT_REASON_DEFINE(JetsonRequestedReboot)

--- a/main_board/src/runner/runner.c
+++ b/main_board/src/runner/runner.c
@@ -33,6 +33,10 @@
 #include <memfault/metrics/connectivity.h>
 #endif
 
+#if defined(CONFIG_MEMFAULT)
+#include <memfault/core/reboot_tracking.h>
+#endif
+
 LOG_MODULE_REGISTER(runner, CONFIG_RUNNER_LOG_LEVEL);
 
 K_THREAD_STACK_DEFINE(runner_process_stack, THREAD_STACK_SIZE_RUNNER);
@@ -287,16 +291,6 @@ handle_shutdown(job_t *job)
     if (delay > 30) {
         job_ack(orb_mcu_Ack_ErrorCode_RANGE, job);
     } else {
-        // Send out shutdown scheduled CAN message
-        orb_mcu_main_ShutdownScheduled shutdown;
-        shutdown.shutdown_reason =
-            orb_mcu_main_ShutdownScheduled_ShutdownReason_JETSON_REQUESTED_REBOOT;
-        shutdown.has_ms_until_shutdown = true;
-        shutdown.ms_until_shutdown = delay * 1000;
-        publish_new(&shutdown, sizeof(shutdown),
-                    orb_mcu_main_McuToJetson_shutdown_tag,
-                    CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
-
         int ret = reboot(delay);
 
         if (ret == RET_SUCCESS) {
@@ -321,6 +315,20 @@ handle_reboot_message(job_t *job)
         job_ack(orb_mcu_Ack_ErrorCode_RANGE, job);
         LOG_ERR("Reboot with delay > 60 seconds: %u", delay);
     } else {
+        // Send out shutdown scheduled CAN message
+        orb_mcu_main_ShutdownScheduled shutdown;
+        shutdown.shutdown_reason =
+            orb_mcu_main_ShutdownScheduled_ShutdownReason_JETSON_REQUESTED_REBOOT;
+        shutdown.has_ms_until_shutdown = true;
+        shutdown.ms_until_shutdown = delay * 1000;
+        publish_new(&shutdown, sizeof(shutdown),
+                    orb_mcu_main_McuToJetson_shutdown_tag,
+                    CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
+#ifdef CONFIG_MEMFAULT
+        MEMFAULT_REBOOT_MARK_RESET_IMMINENT(
+            kMfltRebootReason_JetsonRequestedReboot);
+#endif
+
         int ret = reboot(delay);
 
         if (ret == RET_SUCCESS) {

--- a/main_board/src/runner/runner.c
+++ b/main_board/src/runner/runner.c
@@ -315,24 +315,23 @@ handle_reboot_message(job_t *job)
         job_ack(orb_mcu_Ack_ErrorCode_RANGE, job);
         LOG_ERR("Reboot with delay > 60 seconds: %u", delay);
     } else {
-        // Send out shutdown scheduled CAN message
-        orb_mcu_main_ShutdownScheduled shutdown;
-        shutdown.shutdown_reason =
-            orb_mcu_main_ShutdownScheduled_ShutdownReason_JETSON_REQUESTED_REBOOT;
-        shutdown.has_ms_until_shutdown = true;
-        shutdown.ms_until_shutdown = delay * 1000;
-        publish_new(&shutdown, sizeof(shutdown),
-                    orb_mcu_main_McuToJetson_shutdown_tag,
-                    CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
-#ifdef CONFIG_MEMFAULT
-        MEMFAULT_REBOOT_MARK_RESET_IMMINENT(
-            kMfltRebootReason_JetsonRequestedReboot);
-#endif
-
         int ret = reboot(delay);
 
         if (ret == RET_SUCCESS) {
             job_ack(orb_mcu_Ack_ErrorCode_SUCCESS, job);
+            // Send out shutdown scheduled CAN message
+            orb_mcu_main_ShutdownScheduled shutdown;
+            shutdown.shutdown_reason =
+                orb_mcu_main_ShutdownScheduled_ShutdownReason_JETSON_REQUESTED_REBOOT;
+            shutdown.has_ms_until_shutdown = true;
+            shutdown.ms_until_shutdown = delay * 1000;
+            publish_new(&shutdown, sizeof(shutdown),
+                        orb_mcu_main_McuToJetson_shutdown_tag,
+                        CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
+#ifdef CONFIG_MEMFAULT
+            MEMFAULT_REBOOT_MARK_RESET_IMMINENT(
+                kMfltRebootReason_JetsonRequestedReboot);
+#endif
         } else {
             job_ack(orb_mcu_Ack_ErrorCode_FAIL, job);
         }

--- a/main_board/src/runner/runner.c
+++ b/main_board/src/runner/runner.c
@@ -287,6 +287,16 @@ handle_shutdown(job_t *job)
     if (delay > 30) {
         job_ack(orb_mcu_Ack_ErrorCode_RANGE, job);
     } else {
+        // Send out shutdown scheduled CAN message
+        orb_mcu_main_ShutdownScheduled shutdown;
+        shutdown.shutdown_reason =
+            orb_mcu_main_ShutdownScheduled_ShutdownReason_JETSON_REQUESTED_REBOOT;
+        shutdown.has_ms_until_shutdown = true;
+        shutdown.ms_until_shutdown = delay * 1000;
+        publish_new(&shutdown, sizeof(shutdown),
+                    orb_mcu_main_McuToJetson_shutdown_tag,
+                    CONFIG_CAN_ADDRESS_DEFAULT_REMOTE);
+
         int ret = reboot(delay);
 
         if (ret == RET_SUCCESS) {

--- a/west.yml
+++ b/west.yml
@@ -22,7 +22,7 @@ manifest:
       remote: memfault
       revision: 1.17.0
     - name: orb-messages
-      revision: 44de6d08fb329da43db9276866d51effc6595fcf
+      revision: d303b8ae88c96559b08336fdbcdcc55e3ea27698
       path: modules/orb-messages/public
     - name: priv-orb-messages
       revision: 24b1543547649818bc236ecb9a1ed5794b7f57d0


### PR DESCRIPTION
https://github.com/worldcoin/orb-messages/pull/42 needs to go in first, then dependency in `west.yml` will be updated in a follow-up commit

publish ShutdownScheduled msg w/JETSON_REQUESTED_REBOOT on mcu-util reboot

fixes ORBP-363