### PR TITLE
fix(pubsub): compute McuMessage wrapper size without throwing error

### DIFF
--- a/lib/include/mcu_message_wrapper.h
+++ b/lib/include/mcu_message_wrapper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/** The McuMessage has one, and only one, of a few different inner payloads,
+ * and we want to know how many bytes are used to wrap that inner payload into
+ * the McuMessage. Because all the payloads have a known size at compile time,
+ * we can use the MAX macro to find the size of the largest payload and then
+ * subtract that from the size of the McuMessage.
+ */
+#define MCU_MESSAGE_BIGGEST_PAYLOAD_SIZE                                       \
+    MAX(MAX(MAX(orb_mcu_main_JetsonToMcu_size, orb_mcu_sec_JetsonToSec_size),  \
+            orb_mcu_main_McuToJetson_size),                                    \
+        orb_mcu_sec_SecToJetson_size)
+#define MCU_MESSAGE_ENCODED_WRAPPER_SIZE                                       \
+    (orb_mcu_McuMessage_size - MCU_MESSAGE_BIGGEST_PAYLOAD_SIZE)

--- a/main_board/src/pubsub/pubsub.h
+++ b/main_board/src/pubsub/pubsub.h
@@ -1,21 +1,10 @@
 #pragma once
 
 #include "mcu.pb.h"
+#include "mcu_message_wrapper.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
-#if JetsonToMcu_size >= JetsonToSec_size &&                                    \
-    JetsonToMcu_size >= McuToJetson_size &&                                    \
-    JetsonToMcu_size >= orb_sec_SecToJetson_size
-#define MCU_MESSAGE_ENCODED_WRAPPER_SIZE                                       \
-    (orb_mcu_McuMessage_size - orb_mcu_main_JetsonToMcu_size)
-#else
-// A payload is larger than JetsonToMcu which does not allow to find the number
-// of bytes needed to wrap the payload into an McuMessage. Please use another
-// field to calculate the number of bytes needed to wrap the payload.
-#error Unable to calculate bytes needed to wrap a payload into an McuMessage.
-#endif
 
 /**
  * @brief Starts publishing messages addressed to `remote_addr`


### PR DESCRIPTION
because we want to minimize memory used to store messages to send, we compute the number of bytes taken to wrap the payload to send into an McuMessage.
The number of bytes is guessed thanks to the McuMessage max size and all
 the payloads max sizes which are all known at compile time.
In case the biggest payload among the 4 available changes, the computation needs to change: we now use the max of all 4 so that we don't have to throw an error in case the biggest payload changes.