### PR TITLE
refactor(voltage_measurement): remove redundant code

### DIFF
--- a/main_board/src/voltage_measurement/voltage_measurement.c
+++ b/main_board/src/voltage_measurement/voltage_measurement.c
@@ -201,10 +201,10 @@ voltage_measurement_get_vref_mv(void)
 
     if (vrefint_raw == 0) {
         return 0;
-    } else {
-        return voltage_measurement_get_vref_mv_from_raw(hardware_version,
-                                                        vrefint_raw);
     }
+
+    return voltage_measurement_get_vref_mv_from_raw(hardware_version,
+                                                    vrefint_raw);
 }
 
 static ret_code_t

--- a/main_board/src/voltage_measurement/voltage_measurement.h
+++ b/main_board/src/voltage_measurement/voltage_measurement.h
@@ -49,7 +49,7 @@ typedef enum {
     CHANNEL_COUNT
 } voltage_measurement_channel_t;
 
-static inline uint16_t
+__maybe_unused static uint16_t
 voltage_measurement_get_vref_mv_from_raw(
     orb_mcu_Hardware_OrbVersion hardware_version, uint16_t vrefint_raw)
 {


### PR DESCRIPTION
`inline` not needed (global static)
`else` branch not needed as previous branch returns, so make it clearer.