### PR TITLE
fix(dfu): buffer overflow

### DIFF
--- a/lib/include/utils.h
+++ b/lib/include/utils.h
@@ -52,4 +52,11 @@
     } while (0)
 #endif
 
+// Limit scope of variable to current file depending on whether we are testing
+// or not. When testing, we want to be able to access the variable from other
+// files.
+#ifdef CONFIG_ZTEST
+#define STATIC_OR_EXTERN
+#else
 #define STATIC_OR_EXTERN static
+#endif

--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -45,8 +45,14 @@ static K_MUTEX_DEFINE(analog_and_i2c_mutex);
 #ifdef CONFIG_ZTEST_NEW_API
 #include <zephyr/ztest.h>
 
+// generic tests
 ZTEST_SUITE(hil, NULL, NULL, NULL, NULL, NULL);
 
+// dfu unit tests
+#include "system/dfu/dfu_tests.h"
+ZTEST_SUITE(dfu, NULL, NULL, NULL, dfu_test_reset, NULL);
+
+// ir camera unit tests
 #include "optics/ir_camera_system/ir_camera_system.h"
 
 /**

--- a/main_board/src/system/dfu/dfu_tests.h
+++ b/main_board/src/system/dfu/dfu_tests.h
@@ -1,0 +1,9 @@
+#ifndef DFU_TESTS_H
+#define DFU_TESTS_H
+
+#ifdef CONFIG_ZTEST
+void
+dfu_test_reset(void *fixture);
+#endif
+
+#endif // DFU_TESTS_H


### PR DESCRIPTION
When loading dfu data, if the block_count was larger than what the partition can accept, the processing thread would exit with an error without resetting its internal `dfu_state`, and thus the `wr_idx`. This allowed to write after the buffer boundaries.

Internal state is now reset, and wr_idx and data size always checked before writing the buffer.

Unit tests have been added to validate DFU logic, including valid and edge case scenarios for sequencing, buffer integrity, and semaphore handling.

fixes SEC-1325