### PR TITLE
refactor(ir-camera): move test reset function

### DIFF
--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -54,21 +54,6 @@ ZTEST_SUITE(dfu, NULL, NULL, NULL, dfu_test_reset, NULL);
 
 // ir camera unit tests
 #include "optics/ir_camera_system/ir_camera_system.h"
-
-/**
- * Cleanup function for the test suite, called before & after each ir_camera
- * test
- * @param fixture
- */
-static void
-ir_camera_test_reset(void *fixture)
-{
-    ARG_UNUSED(fixture);
-    ir_camera_system_enable_leds(
-        orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_NONE);
-    ir_camera_system_set_fps(0);
-    ir_camera_system_set_on_time_us(0);
-}
 ZTEST_SUITE(ir_camera, NULL, NULL, ir_camera_test_reset, ir_camera_test_reset,
             NULL);
 #endif

--- a/main_board/src/optics/ir_camera_system/ir_camera_system.c
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.c
@@ -84,6 +84,23 @@ STATIC_OR_EXTERN orb_mcu_main_InfraredLEDs_Wavelength enabled_led_wavelength =
 
 /* Module internal */
 
+#ifdef CONFIG_ZTEST
+/**
+ * Cleanup function for the test suite, called before & after each ir_camera
+ * test
+ * @param fixture
+ */
+void
+ir_camera_test_reset(void *fixture)
+{
+    ARG_UNUSED(fixture);
+    ir_camera_system_enable_leds(
+        orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_NONE);
+    ir_camera_system_set_fps(0);
+    ir_camera_system_set_on_time_us(0);
+}
+#endif
+
 // Focus sweep
 bool
 get_focus_sweep_in_progress(void)

--- a/main_board/src/optics/ir_camera_system/ir_camera_system.h
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.h
@@ -10,6 +10,9 @@
      (sizeof(uint16_t)))
 
 #ifdef CONFIG_ZTEST
+void
+ir_camera_test_reset(void *fixture);
+
 // in tests we don't want to wait for too long
 #define IR_LED_AUTO_OFF_TIMEOUT_S (5) // ztest - 5 seconds
 #else


### PR DESCRIPTION
in ir_camera_system.c, so that it doesn't bloat main.c