### PR TITLE
feat(diag): fix synchronization

### DIFF
--- a/main_board/log_levels.Kconfig
+++ b/main_board/log_levels.Kconfig
@@ -82,6 +82,10 @@ module = VOLTAGE_MEASUREMENT
 module-str = VOLTAGE_MEASUREMENT
 source "subsys/logging/Kconfig.template.log_config"
 
+module = DIAG
+module-str = DIAG
+source "subsys/logging/Kconfig.template.log_config"
+
 module = SC18IS606
 module-str = SC18IS606
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
diag_sync must not return is diag data didn't change since last sync, because memfault data is being queued.