### PR TITLE
fix(ztests): unit tests for diamond evt

### DIFF
--- a/main_board/src/pubsub/pubsub_tests.c
+++ b/main_board/src/pubsub/pubsub_tests.c
@@ -1,5 +1,6 @@
 #include "mcu.pb.h"
 #include "pubsub.h"
+#include "system/version/version.h"
 #include <errors.h>
 #include <utils.h>
 #include <zephyr/kernel.h>
@@ -134,9 +135,22 @@ ZTEST(hil, test_pubsub_sent_messages)
         0);
     zassert_not_equal(
         mcu_to_jetson_payloads & (1 << orb_mcu_main_McuToJetson_tof_1d_tag), 0);
-    zassert_not_equal(mcu_to_jetson_payloads &
-                          (1 << orb_mcu_main_McuToJetson_front_als_tag),
-                      0);
+
+    // init to 0 so that the test is performed by default
+    // won't be done on diamond with front-unit 6.3x
+    uint32_t fu_version = 0;
+#if defined(CONFIG_BOARD_DIAMOND_MAIN)
+    fu_version = version_get_front_unit_rev();
+#endif
+    if (fu_version <
+            orb_mcu_Hardware_FrontUnitVersion_FRONT_UNIT_VERSION_V6_3A ||
+        fu_version >
+            orb_mcu_Hardware_FrontUnitVersion_FRONT_UNIT_VERSION_V6_3C) {
+        zassert_not_equal(mcu_to_jetson_payloads &
+                              (1 << orb_mcu_main_McuToJetson_front_als_tag),
+                          0);
+    }
+
     zassert_not_equal(mcu_to_jetson_payloads &
                           (1 << orb_mcu_main_McuToJetson_hardware_diag_tag),
                       0);

--- a/main_board/src/temperature/fan/fan_tests.c
+++ b/main_board/src/temperature/fan/fan_tests.c
@@ -24,8 +24,6 @@ ZTEST(hil, test_fan_set_speed)
 
 ZTEST(hil, test_fan_tachometer)
 {
-    Z_TEST_SKIP_IFDEF(CONFIG_BOARD_DIAMOND_MAIN);
-
     // "fast" speed, then revert to initial speed
     fan_set_speed_by_percentage(FAN_INITIAL_SPEED_PERCENT + 5);
     k_msleep(5000);

--- a/main_board/src/voltage_measurement/voltage_measurement_tests.c
+++ b/main_board/src/voltage_measurement/voltage_measurement_tests.c
@@ -24,10 +24,12 @@ ZTEST(hil, test_voltage_measurements)
     LOG_INF("PVCC = %d mV", voltage_mv);
     zassert_between_inclusive(voltage_mv, 30590, 32430);
 
+#ifdef CONFIG_BOARD_PEARL_MAIN
     ret = voltage_measurement_get(CHANNEL_12V, &voltage_mv);
     zassert_equal(ret, RET_SUCCESS);
     LOG_INF("12V = %d mV", voltage_mv);
     zassert_between_inclusive(voltage_mv, 11700, 12840);
+#endif
 
     ret = voltage_measurement_get(CHANNEL_12V_CAPS, &voltage_mv);
     zassert_equal(ret, RET_SUCCESS);


### PR DESCRIPTION
12v not present on diamond evt board
re-enable fan tach test
als is removed until further notice

fixes ORBP-660