### PR TITLE
Add a .clangd config so clangd can find the compilation database

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+  Remove: [-fno-reorder-functions, -mfp16-format=ieee]
+  CompilationDatabase: main_board/build


### PR DESCRIPTION
Also remove some compilation flags that are not understood by clang (gcc specific compilation flags that Zephyr seems to automatically supply)