### PR TITLE
feat(certifications): allow large IR on-time duration

### DIFF
--- a/main_board/src/optics/ir_camera_system/ir_camera_timer_settings.h
+++ b/main_board/src/optics/ir_camera_system/ir_camera_timer_settings.h
@@ -17,14 +17,14 @@ BUILD_ASSERT(IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US == 5000 &&
              "to ensure hardware safty circuit is not triggered.");
 #endif // !defined(CONFIG_ZTEST)
 #else
-#define IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US 8000
-#define IR_CAMERA_SYSTEM_MAX_IR_LED_DUTY_CYCLE 0.25
+#define IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US (UINT16_MAX - 1)
+#define IR_CAMERA_SYSTEM_MAX_IR_LED_DUTY_CYCLE 1.0
 #if !defined(CONFIG_ZTEST)
-BUILD_ASSERT(IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US == 8000 &&
-                 IR_CAMERA_SYSTEM_MAX_IR_LED_DUTY_CYCLE == 0.25,
-             "These limits are to ensure that the hardware safty circuit is "
-             "not triggered. If you change them please test with multiple orbs "
-             "to ensure hardware safty circuit is not triggered.");
+// BUILD_ASSERT(IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US == 8000 &&
+//                  IR_CAMERA_SYSTEM_MAX_IR_LED_DUTY_CYCLE == 0.25,
+//              "These limits are to ensure that the hardware safty circuit is "
+//              "not triggered. If you change them please test with multiple
+//              orbs " "to ensure hardware safty circuit is not triggered.");
 #endif // !defined(CONFIG_ZTEST)
 #endif
 #define IR_CAMERA_SYSTEM_MAX_FPS 60


### PR DESCRIPTION
to test that the system responds correctly, allow large IR LED duty-cycle.
Too high values should trigger the safety circuitry and stop IR LED to work.

@vmenge to test on unit
