### PR TITLE
feat(ir-camera): conditions to enable/disable ir leds & capture

### DIFF
--- a/main_board/src/optics/ir_camera_system/ir_camera_system.h
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.h
@@ -117,7 +117,9 @@ bool
 ir_camera_system_2d_tof_camera_is_enabled(void);
 
 /**
- * @brief Enable IR LEDs
+ * @brief Enable a group of IR LEDs, or disable them.
+ *
+ * Passing WAVELENGTH_NONE will disable LEDs and is accepted in any condition.
  *
  * @retval RET_SUCCESS LEDs enabled at corresponding @c wavelength
  * @retval RET_ERROR_NOT_INITIALIZED not initialized
@@ -148,6 +150,7 @@ ir_camera_system_get_time_until_update_us(void);
  * - IR-LEDs duty cycle (on-time) <= 15% (Pearl) OR <= 25% (Diamond)
  * AND
  * - the maximum Frames-Per-Second of 60Hz is not exceeded.
+ * It is allowed to reset the FPS to 0 in any condition.
  * @param fps Frames-Per-Second, maximum is 60
  * @retval RET_ERROR_INVALID_PARAM: FPS value isn't valid: max FPS or max duty
  *         cycle exceeded
@@ -167,10 +170,11 @@ ir_camera_system_get_fps(void);
 
 /**
  * Set IR LEDs on duration for 940nm and 850nm LEDs
- * Settings are computed if a duty cycle <= 15% (Pearl)/ 25% (Diamond) and a
+ * Settings are computed if a duty cycle <= 15% (Pearl) / 25% (Diamond) and a
  * maximum on-time of 5000 us (pearl) / 8000 us (diamond) is not exceeded.
  * Exceeding the maximum on-time will result in unchanged settings and an
  * RET_ERROR_INVALID_PARAM.
+ * It is allowed to reset the duration to 0 in any condition.
  *
  * @param on_time_us LED on duration, maximum is 5000 (pearl) / 8000 (diamond)
  * @retval RET_ERROR_INVALID_PARAM: \c on_time_us isn't valid, max duty cycle or

--- a/main_board/src/optics/ir_camera_system/ir_camera_system.h
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.h
@@ -275,6 +275,8 @@ ir_camera_system_perform_mirror_sweep(void);
  * and one needs to call `ir_camera_system_init()`.
  * @retval RET_ERROR_BUSY: Some uninterruptible function is in progress, like a
  * focus sweep. Said function will terminate eventually.
+ * @retval RET_ERROR_FORBIDDEN: distance measured in front by 1d-tof is too
+ * close, or PVCC is not enabled because safety circuitry tripped.
  */
 ret_code_t
 ir_camera_system_get_status(void);

--- a/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/template_main.c
+++ b/main_board/src/optics/ir_camera_system/unit_tests/ir_camera_system/template_main.c
@@ -397,11 +397,12 @@ ZTEST(ir_camera_system_api, test_get_enabled_wavelength)
 
     set_focus_sweep_in_progress();
 
+	// allow force-stop in any condition
     ir_camera_system_enable_leds(orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_NONE);
-    // should be unchanged
-    zassert_equal(enabled_led_wavelength, orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_ONE);
+    // should have changed
+    zassert_equal(enabled_led_wavelength, orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_NONE);
     w = ir_camera_system_get_enabled_leds();
-    zassert_equal(w, orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_ONE);
+    zassert_equal(w, orb_mcu_main_InfraredLEDs_Wavelength_WAVELENGTH_NONE);
 }
 
 ZTEST(ir_camera_system_api, test_set_fps_success)
@@ -426,6 +427,7 @@ ZTEST(ir_camera_system_api, test_set_fps_fail_because_fps_out_of_range)
     ir_camera_system_init();
 
     ret = ir_camera_system_set_fps(IR_CAMERA_SYSTEM_MAX_FPS + 1);
+
     zassert_equal(ret, RET_ERROR_INVALID_PARAM);
 }
 

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -15,103 +15,29 @@ LOG_MODULE_REGISTER(optics);
 static orb_mcu_HardwareDiagnostic_Status self_test_status =
     orb_mcu_HardwareDiagnostic_Status_STATUS_UNKNOWN;
 
-static ATOMIC_DEFINE(fu_pvcc_enabled, 1);
-#define ATOMIC_FU_PVCC_ENABLED_BIT 0
-
 // pin allows us to check whether PVCC is enabled on the front unit
 // PVCC might be disabled by hardware due to an intense usage of the IR LEDs
 // that doesn't respect the eye safety constraints
 static struct gpio_dt_spec front_unit_pvcc_enabled = GPIO_DT_SPEC_GET_BY_IDX(
     DT_PATH(zephyr_user), front_unit_pvcc_enabled_gpios, 0);
 
-#if defined(CONFIG_BOARD_PEARL_MAIN)
-
-static struct gpio_callback fu_pvcc_enabled_cb_data;
-
-static void
-front_unit_pvcc_update(struct k_work *work);
-
-static K_WORK_DEFINE(front_unit_pvcc_event_work, front_unit_pvcc_update);
-
-/// Handle PVCC/3v3 line modifications on the front unit
-/// Communicate change to Jetson
-static void
-front_unit_pvcc_update(struct k_work *work)
-{
-    ARG_UNUSED(work);
-
-    orb_mcu_HardwareDiagnostic_Status status =
-        orb_mcu_HardwareDiagnostic_Status_STATUS_OK;
-
-    bool pvcc_available = (gpio_pin_get_dt(&front_unit_pvcc_enabled) != 0);
-    if (pvcc_available) {
-        atomic_set_bit(fu_pvcc_enabled, ATOMIC_FU_PVCC_ENABLED_BIT);
-        LOG_INF("Circuitry allows usage of IR LEDs");
-    } else {
-        atomic_clear_bit(fu_pvcc_enabled, ATOMIC_FU_PVCC_ENABLED_BIT);
-
-        status = orb_mcu_HardwareDiagnostic_Status_STATUS_OK;
-        LOG_WRN("Eye safety circuitry tripped");
-    }
-
-    diag_set_status(orb_mcu_HardwareDiagnostic_Source_OPTICS_IR_LEDS, status);
-}
-
-static void
-interrupt_fu_pvcc_handler(const struct device *dev, struct gpio_callback *cb,
-                          uint32_t pins)
-{
-    ARG_UNUSED(dev);
-    ARG_UNUSED(cb);
-
-    if (pins & BIT(front_unit_pvcc_enabled.pin)) {
-        k_work_submit(&front_unit_pvcc_event_work);
-    }
-}
-
-static int
-configure_front_unit_3v3_detection(void)
-{
-    int ret = gpio_pin_configure_dt(&front_unit_pvcc_enabled, GPIO_INPUT);
-    if (ret) {
-        ASSERT_SOFT(ret);
-        return ret;
-    }
-
-    ret = gpio_pin_interrupt_configure_dt(&front_unit_pvcc_enabled,
-                                          GPIO_INT_EDGE_BOTH);
-    if (ret != 0) {
-        ASSERT_SOFT(ret);
-        return ret;
-    }
-
-    gpio_init_callback(&fu_pvcc_enabled_cb_data, interrupt_fu_pvcc_handler,
-                       BIT(front_unit_pvcc_enabled.pin));
-    ret = gpio_add_callback(front_unit_pvcc_enabled.port,
-                            &fu_pvcc_enabled_cb_data);
-    if (ret != 0) {
-        ASSERT_SOFT(ret);
-    }
-
-    // set initial state
-    k_work_submit(&front_unit_pvcc_event_work);
-
-    return ret;
-}
-#endif
-
-bool
-optics_usable(void)
-{
-    atomic_val_t pvcc_enabled = atomic_get(fu_pvcc_enabled);
-    return ((pvcc_enabled & BIT(ATOMIC_FU_PVCC_ENABLED_BIT)) != 0) &&
-           distance_is_safe();
-}
-
 bool
 optics_safety_circuit_triggered(void)
 {
-    atomic_val_t pvcc_enabled = atomic_get(fu_pvcc_enabled);
+    int ret = gpio_pin_get_dt(&front_unit_pvcc_enabled);
+    ASSERT_SOFT_BOOL(ret >= 0);
+
+    bool pvcc_enabled = (ret >= 0 && ret != 0);
+
+    // update status
+    if (pvcc_enabled) {
+        diag_set_status(orb_mcu_HardwareDiagnostic_Source_OPTICS_IR_LEDS,
+                        orb_mcu_HardwareDiagnostic_Status_STATUS_OK);
+    } else {
+        diag_set_status(orb_mcu_HardwareDiagnostic_Source_OPTICS_IR_LEDS,
+                        orb_mcu_HardwareDiagnostic_Status_STATUS_SAFETY_ISSUE);
+    }
+
     return !pvcc_enabled;
 }
 
@@ -163,29 +89,16 @@ optics_init(const orb_mcu_Hardware *hw_version, struct k_mutex *mutex)
         return err_code;
     }
 
-#if defined(CONFIG_BOARD_PEARL_MAIN)
-    err_code = configure_front_unit_3v3_detection();
+    err_code = gpio_pin_configure_dt(&front_unit_pvcc_enabled, GPIO_INPUT);
     if (err_code) {
         ASSERT_SOFT(err_code);
         return err_code;
     }
-#else
-    int ret = gpio_pin_configure_dt(&front_unit_pvcc_enabled, GPIO_INPUT);
-    if (ret) {
-        ASSERT_SOFT(ret);
-        return ret;
-    }
 
-    if (gpio_pin_get_dt(&front_unit_pvcc_enabled) != 0) {
-        LOG_INF("Circuitry allows usage of IR LEDs");
-    } else {
-        LOG_WRN("Eye safety circuitry tripped");
-    }
-
-    atomic_set_bit(fu_pvcc_enabled, ATOMIC_FU_PVCC_ENABLED_BIT);
-
-    UNUSED_PARAMETER(hw_version);
-#endif
+    // check pvcc (& update diag)
+    bool safety_triggered = optics_safety_circuit_triggered();
+    LOG_INF("Safety circuitry triggered: %u", safety_triggered);
+    UNUSED_VARIABLE(safety_triggered);
 
     return err_code;
 }

--- a/main_board/src/optics/optics.h
+++ b/main_board/src/optics/optics.h
@@ -5,20 +5,9 @@
 #include <zephyr/kernel.h>
 
 /**
- * @brief Check whether the optics components are usable
- *
- * @details Check if the hardware eye safety circuitry has been tripped in case
- *  IR leds are too heavily used or if the distance of any object in front
- *  isn't too close.
- *
- * @return true if usable, false otherwise
- */
-bool
-optics_usable(void);
-
-/**
  * @brief Check if the eye safety circuitry has been tripped
  *
+ * ⚠️ on diamond: not ISR-safe, because pvcc-enabled pin is on gpio expander
  * @return true if tripped, false otherwise
  */
 bool


### PR DESCRIPTION
- check IR safety circuitry state (pvcc enabled) on setting new FPS, IR LED, wavelength
- allow reset of fps and ir-led to zero in any condition