### PR TITLE
chore(temperature): increase mutex lock timeout from 100 to 500ms

### DIFF
--- a/main_board/src/temperature/sensors/temperature.c
+++ b/main_board/src/temperature/sensors/temperature.c
@@ -536,8 +536,7 @@ get_ambient_temperature(const struct device *dev, int32_t *temp,
         if (device_is_ready(dev) == false) {
             return RET_ERROR_NOT_INITIALIZED;
         }
-        if (k_mutex_lock(temperature_i2c_mux_mutex, K_MSEC(100)) != 0) {
-            LOG_ERR("Could not lock mutex.");
+        if (k_mutex_lock(temperature_i2c_mux_mutex, K_MSEC(500)) != 0) {
             return RET_ERROR_BUSY;
         }
         ret = sensor_sample_fetch(dev);


### PR DESCRIPTION
i2c can be locked for longer than 100ms, as experienced when some higher prio threads are holding the cpu for long times. remove error message on mutex busy, as there is an error message to catch when temperature sensors cannot be reached for more than 5 times (TEMPERATURE_SAMPLE_RETRY_COUNT)