### PR TITLE
chore(1d-tof): diamond: disable to avoid ir light leakage into rgb

### DIFF
--- a/main_board/CMakeLists.txt
+++ b/main_board/CMakeLists.txt
@@ -81,7 +81,6 @@ list(APPEND SOURCES_FILES
     src/main.c
 
     src/optics/optics.c
-    src/optics/1d_tof/tof_1d.c
     src/optics/ir_camera_system/ir_camera_timer_settings.c
     src/optics/ir_camera_system/ir_camera_system_hw.c
     src/optics/ir_camera_system/ir_camera_system.c
@@ -135,6 +134,10 @@ if (CONFIG_BOARD_DIAMOND_MAIN)
         list(APPEND SOURCES_FILES src/ui/rgb_leds/cone_leds/cone_leds.c)
     endif()
     list(APPEND SOURCES_FILES src/ui/white_leds/white_leds.c)
+endif()
+
+if (CONFIG_PROXIMITY_DETECTION_FOR_IR_SAFETY)
+    list(APPEND SOURCES_FILES src/optics/1d_tof/tof_1d.c)
 endif()
 
 if (CONFIG_ZTEST)

--- a/main_board/src/optics/ir_camera_system/ir_camera_system.c
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system.c
@@ -7,10 +7,19 @@
 #include "utils.h"
 
 #if !defined(IR_CAMERA_UNIT_TESTS)
-// include reference to function in case outside of unit tests, otherwise
+// include reference to function in case outside unit tests, otherwise
 // mock them.
 #include <optics/1d_tof/tof_1d.h>
 #include <optics/optics.h>
+
+#ifndef CONFIG_PROXIMITY_DETECTION_FOR_IR_SAFETY
+bool
+distance_is_safe()
+{
+    return true;
+}
+#endif
+
 #else
 /** mocked function below for unit tests */
 static bool
@@ -18,6 +27,7 @@ distance_is_safe()
 {
     return true;
 }
+
 static bool
 optics_safety_circuit_triggered()
 {

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -85,13 +85,13 @@ optics_init(const orb_mcu_Hardware *hw_version, struct k_mutex *mutex)
 
 #if PROXIMITY_DETECTION_FOR_IR_SAFETY
     err_code = tof_1d_init(distance_is_unsafe_cb, mutex);
-#else
-    err_code = tof_1d_init(NULL, mutex);
-#endif
     if (err_code) {
         ASSERT_SOFT(err_code);
         return err_code;
     }
+#else
+    UNUSED_PARAMETER(mutex);
+#endif
 
     err_code = gpio_pin_configure_dt(&front_unit_pvcc_enabled, GPIO_INPUT);
     if (err_code) {


### PR DESCRIPTION
disable until we synchronize 1d-tof with rgb frame capture