### PR TITLE
fix(i2c1): use mutex to protect i2c1 bus usage

### DIFF
--- a/main_board/src/optics/ir_camera_system/ir_camera_system_tests.c
+++ b/main_board/src/optics/ir_camera_system/ir_camera_system_tests.c
@@ -372,8 +372,11 @@ ZTEST(ir_camera, test_ir_camera_invalid_wavelengths)
 ZTEST(ir_camera, test_ir_camera_valid_on_time_and_duty_limits)
 {
     bool safety_circuit_tripped;
+    int ret;
 
-    safety_circuit_tripped = optics_safety_circuit_triggered();
+    ret = optics_safety_circuit_triggered(10, &safety_circuit_tripped);
+    zassert_equal(ret, RET_SUCCESS,
+                  "Failed to get safety circuit triggered state");
     zassert_false(safety_circuit_tripped, "PVCC not available");
 
     // set valid on-time
@@ -383,7 +386,9 @@ ZTEST(ir_camera, test_ir_camera_valid_on_time_and_duty_limits)
         1000); // should pass safety circuit shouldn't trip
     ir_camera_system_set_fps(low_fps);
     k_msleep(100);
-    safety_circuit_tripped = optics_safety_circuit_triggered();
+    ret = optics_safety_circuit_triggered(10, &safety_circuit_tripped);
+    zassert_equal(ret, RET_SUCCESS,
+                  "Failed to get safety circuit triggered state");
     zassert_false(
         safety_circuit_tripped,
         "safety circuit tripped but shouldn't at %d fps with %d us on-time",
@@ -417,7 +422,9 @@ ZTEST(ir_camera, test_ir_camera_valid_on_time_and_duty_limits)
         ir_camera_system_set_on_time_us(IR_CAMERA_SYSTEM_MAX_IR_LED_ON_TIME_US);
         k_msleep(100);
 
-        safety_circuit_tripped = optics_safety_circuit_triggered();
+        ret = optics_safety_circuit_triggered(10, &safety_circuit_tripped);
+        zassert_equal(ret, RET_SUCCESS,
+                      "Failed to get safety circuit triggered state");
         zassert_false(safety_circuit_tripped,
                       "safety circuit tripped but shouldn't at %d fps with %d "
                       "us on-time, wavelength %d",
@@ -456,7 +463,9 @@ ZTEST(ir_camera, test_ir_camera_valid_on_time_and_duty_limits)
             ir_camera_system_set_fps(fps);
             k_msleep(100);
 
-            safety_circuit_tripped = optics_safety_circuit_triggered();
+            ret = optics_safety_circuit_triggered(10, &safety_circuit_tripped);
+            zassert_equal(ret, RET_SUCCESS,
+                          "Failed to get safety circuit triggered state");
             zassert_false(safety_circuit_tripped,
                           "safety circuit tripped but shouldn't at %d fps with "
                           "%d us on-time, wavelength %d",

--- a/main_board/src/optics/optics.h
+++ b/main_board/src/optics/optics.h
@@ -8,10 +8,13 @@
  * @brief Check if the eye safety circuitry has been tripped
  *
  * ⚠️ on diamond: not ISR-safe, because pvcc-enabled pin is on gpio expander
- * @return true if tripped, false otherwise
+ * @param timeout_ms time in ms allocated to take the mutex (i2c bus)
+ * @param triggered pointer to status variable, filled on RET_SUCCESS
+ * @return RET_SUCCESS on successfully reading the pvcc-enabled pin
+ * error code otherwise
  */
-bool
-optics_safety_circuit_triggered(void);
+int
+optics_safety_circuit_triggered(const uint32_t timeout_ms, bool *triggered);
 
 /**
  * @brief Initialize the optics components


### PR DESCRIPTION
mutex for i2c is used by 1d-tof, als and temperature module, but not gpio expander pins themselves.
it is needed though for pvcc-enabled which can be checked quite regularly. For the others, because they are only checked during boot (front-unit hardware version), we
 can probably leave them unprotected.