### PR TITLE
fix(storage): reset bad storage area during flush

### DIFF
--- a/main_board/src/pubsub/pubsub.c
+++ b/main_board/src/pubsub/pubsub.c
@@ -143,11 +143,13 @@ pub_stored_thread()
             // no more records, terminate thread
             return;
         case RET_ERROR_NO_MEM:
-        case RET_ERROR_INVALID_STATE:
-        default:
-            LOG_ERR("Discarding stored record, err %u", err_code);
             storage_free();
             continue;
+
+        case RET_ERROR_INVALID_STATE:
+            // area has been reset on error, no more records
+        default:
+            return;
         }
 
         if (!publish_is_started(record.destination)) {


### PR DESCRIPTION
when reading (storage peek + storage free), if the area is in a bad state, there was no mechanism to reset the area and thus the thread ended up in a while loop trying to read an unreadable record without being able to free that record.