### PR TITLE
fix(boot): fix sd card boot

### DIFF
--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -284,6 +284,26 @@ initialize(void)
     err_code = ui_init();
     ASSERT_SOFT(err_code);
 
+    err_code = als_init(&hw, &analog_and_i2c_mutex);
+    ASSERT_SOFT(err_code);
+
+    err_code = dfu_init();
+    ASSERT_SOFT(err_code);
+
+    err_code = button_init();
+    ASSERT_SOFT(err_code);
+
+#if defined(CONFIG_BOARD_PEARL_MAIN)
+    err_code = gnss_init();
+    ASSERT_SOFT(err_code);
+#endif
+
+    err_code = fan_tach_init();
+    ASSERT_SOFT(err_code);
+
+    // wait that jetson boots to enable super-caps as it's drawing a lot of
+    // current that is needed for proper jetson boot
+    k_msleep(20000);
 #if !defined(CONFIG_NO_SUPER_CAPS) && !defined(CONFIG_CI_INTEGRATION_TESTS)
     err_code = boot_turn_on_super_cap_charger();
     if (err_code == RET_SUCCESS) {
@@ -301,23 +321,6 @@ initialize(void)
     err_code = optics_init(&hw);
     ASSERT_SOFT(err_code);
 #endif // CONFIG_NO_SUPER_CAPS
-
-    err_code = als_init(&hw, &analog_and_i2c_mutex);
-    ASSERT_SOFT(err_code);
-
-    err_code = dfu_init();
-    ASSERT_SOFT(err_code);
-
-    err_code = button_init();
-    ASSERT_SOFT(err_code);
-
-#if defined(CONFIG_BOARD_PEARL_MAIN)
-    err_code = gnss_init();
-    ASSERT_SOFT(err_code);
-#endif
-
-    err_code = fan_tach_init();
-    ASSERT_SOFT(err_code);
 }
 
 #ifdef CONFIG_ZTEST

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -417,15 +417,10 @@ turn_on_power_supplies(void)
     power_vbat_5v_3v3_supplies_on();
 
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
-    /* an empty super cap takes ~3 to 4 seconds to charge */
-    ret = boot_turn_on_super_cap_charger();
-    ASSERT_SOFT(ret);
-    k_msleep(2000);
-
     ret = gpio_pin_set_dt(&supply_12v_caps_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("12V_CAPS enabled");
-    k_msleep(1000);
+    k_msleep(20);
 
     ret = gpio_pin_set_dt(&supply_5v_rgb_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
@@ -449,7 +444,7 @@ turn_on_power_supplies(void)
 
     ret = gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
-    LOG_INF("3.3V SSD/SD Card power supply enabled");
+    LOG_INF("3.3V SD card power supply enabled");
     k_msleep(20);
 
     ret = gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 1);
@@ -477,7 +472,7 @@ turn_on_power_supplies(void)
     if (version.version == orb_mcu_Hardware_OrbVersion_HW_VERSION_PEARL_EV5) {
         ret = gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
         ASSERT_SOFT(ret);
-        LOG_INF("3.3V SSD/SD Card power supply enabled");
+        LOG_INF("3.3V SSD power supply enabled");
         k_msleep(20);
 
         ret = gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 1);

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -411,52 +411,53 @@ static int
 turn_on_power_supplies(void)
 {
     int ret = 0;
-    orb_mcu_Hardware version = version_get();
 
     // might be a duplicate call, but it's preferable to be sure that
     // these supplies are on
     power_vbat_5v_3v3_supplies_on();
 
-    // Additional control signals for 3V3_SSD and 3V3_WIFI on EV5 and Diamond
-    if (version.version == orb_mcu_Hardware_OrbVersion_HW_VERSION_PEARL_EV5 ||
-        version.version == orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_B3 ||
-        version.version == orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_EVT ||
-        version.version ==
-            orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_V4_4) {
-        ret = gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
-        ASSERT_SOFT(ret);
-        LOG_INF("3.3V SSD/SD Card power supply enabled");
-
-        ret = gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 1);
-        ASSERT_SOFT(ret);
-        LOG_INF("3.3V WIFI power supply enabled");
-    }
-
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
+    /* an empty super cap takes ~3 to 4 seconds to charge */
+    ret = boot_turn_on_super_cap_charger();
+    ASSERT_SOFT(ret);
+    k_msleep(2000);
+
     ret = gpio_pin_set_dt(&supply_12v_caps_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("12V_CAPS enabled");
+    k_msleep(1000);
 
     ret = gpio_pin_set_dt(&supply_5v_rgb_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("5V_RGB enabled");
+    k_msleep(20);
 
     ret = gpio_pin_set_dt(&supply_3v6_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("3V6 enabled");
+    k_msleep(20);
 
     ret = gpio_pin_set_dt(&supply_3v3_lte_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("3V3_LTE enabled");
+    k_msleep(20);
 
     ret = gpio_pin_set_dt(&supply_2v8_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
     LOG_INF("2V8 enabled");
-#endif
+    k_msleep(20);
 
-    k_msleep(100);
+    ret = gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
+    ASSERT_SOFT(ret);
+    LOG_INF("3.3V SSD/SD Card power supply enabled");
+    k_msleep(20);
 
-#if defined(CONFIG_BOARD_PEARL_MAIN)
+    ret = gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 1);
+    ASSERT_SOFT(ret);
+    LOG_INF("3.3V WIFI power supply enabled");
+#elif defined(CONFIG_BOARD_PEARL_MAIN)
+    orb_mcu_Hardware version = version_get();
+
     ret = gpio_pin_set_dt(&supply_12v_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);
 
@@ -472,7 +473,19 @@ turn_on_power_supplies(void)
         ASSERT_SOFT(ret);
         LOG_INF("3.8V enabled");
     }
+
+    if (version.version == orb_mcu_Hardware_OrbVersion_HW_VERSION_PEARL_EV5) {
+        ret = gpio_pin_set_dt(&supply_3v3_ssd_enable_gpio_spec, 1);
+        ASSERT_SOFT(ret);
+        LOG_INF("3.3V SSD/SD Card power supply enabled");
+        k_msleep(20);
+
+        ret = gpio_pin_set_dt(&supply_3v3_wifi_enable_gpio_spec, 1);
+        ASSERT_SOFT(ret);
+        LOG_INF("3.3V WIFI power supply enabled");
+    }
 #endif
+    k_msleep(100);
 
     ret = gpio_pin_set_dt(&supply_1v8_enable_gpio_spec, 1);
     ASSERT_SOFT(ret);


### PR DESCRIPTION
sometimes sd card isn't recognized on _cold_ boot: no battery plugged in for a long time, then with a battery freshly inserted and instant boot, we can easily reproduce the issue.

the difference between cold boot, and a fresh reboot is mainly into the voltage at the (super) capacitors.
The need for current when starting to charge the super-caps might alter the voltage at the sd card and/or other components that are not correctly initialized.
The super-caps are thus enabled later in the boot process (after UEFI boots, which needs ~15 seconds).
With this new boot sequence, the sd card seems to be always correctly detected.
