### PR TITLE
feat(error): optional message with assert

### DIFF
--- a/lib/errors/app_assert.c
+++ b/lib/errors/app_assert.c
@@ -76,16 +76,26 @@ app_assert_hard_handler(int32_t error_code, uint32_t line_num,
 
 __WEAK void
 app_assert_soft_handler(int32_t error_code, uint32_t line_num,
-                        const uint8_t *p_file_name)
+                        const uint8_t *p_file_name, const uint8_t *opt_message)
 {
 #if defined(CONFIG_MEMFAULT)
     // trace, no need to use line_num & p_file_name, cause the backtrace
     // is collected
     UNUSED_PARAMETER(line_num);
     UNUSED_PARAMETER(p_file_name);
-    MEMFAULT_TRACE_EVENT_WITH_LOG(assert, "err %d", error_code);
+    if (opt_message) {
+        MEMFAULT_TRACE_EVENT_WITH_LOG(assert, "err %d: %s", error_code,
+                                      opt_message);
+    } else {
+        MEMFAULT_TRACE_EVENT_WITH_LOG(assert, "err %d", error_code);
+    }
 #else
-    LOG_ERR("%s:%d, error %d", p_file_name, line_num, error_code);
+    if (opt_message != NULL) {
+        LOG_ERR("%s:%d, error %d: %s", p_file_name, line_num, error_code,
+                opt_message);
+    } else {
+        LOG_ERR("%s:%d, error %d", p_file_name, line_num, error_code);
+    }
 #endif
 
     ++error_count;

--- a/lib/errors/include/app_assert.h
+++ b/lib/errors/include/app_assert.h
@@ -38,10 +38,11 @@ app_assert_hard_handler(int32_t error_code, uint32_t line_num,
  * @param error_code
  * @param line_num
  * @param p_file_name
+ * @param opt_message optional message
  */
 void
 app_assert_soft_handler(int32_t error_code, uint32_t line_num,
-                        const uint8_t *p_file_name);
+                        const uint8_t *p_file_name, const uint8_t *opt_message);
 
 /**@brief Macro for calling error handler function if supplied error code any
  * other than 0.
@@ -51,8 +52,17 @@ app_assert_soft_handler(int32_t error_code, uint32_t line_num,
 #define ASSERT_SOFT(ERR_CODE)                                                  \
     do {                                                                       \
         if (ERR_CODE != 0) {                                                   \
+            app_assert_soft_handler((ERR_CODE), __LINE__, (uint8_t *)__FILE__, \
+                                    NULL);                                     \
+        }                                                                      \
+    } while (0)
+
+#define ASSERT_SOFT_WITH_MSG(ERR_CODE, MESSAGE)                                \
+    do {                                                                       \
+        if (ERR_CODE != 0) {                                                   \
             app_assert_soft_handler((ERR_CODE), __LINE__,                      \
-                                    (uint8_t *)__FILE__);                      \
+                                    (const uint8_t *)__FILE__,                 \
+                                    (const uint8_t *)MESSAGE);                 \
         }                                                                      \
     } while (0)
 
@@ -105,7 +115,7 @@ app_assert_soft_handler(int32_t error_code, uint32_t line_num,
 #define ASSERT_SOFT_BOOL(BOOLEAN_VALUE)                                        \
     do {                                                                       \
         if (!(BOOLEAN_VALUE)) {                                                \
-            app_assert_soft_handler(0, __LINE__, (uint8_t *)__FILE__);         \
+            app_assert_soft_handler(0, __LINE__, (uint8_t *)__FILE__, NULL);   \
         }                                                                      \
     } while (0)
 


### PR DESCRIPTION
ASSERT_SOFT_WITH_MSG allows to pass an additional message to bring even more context.