### PR TITLE
feat(1d-tof): dvt support

### DIFF
--- a/boards/tfh/diamond_main/diamond_main.dts
+++ b/boards/tfh/diamond_main/diamond_main.dts
@@ -271,6 +271,12 @@
                 status = "okay";
                 reg = <0x4b>;
             };
+
+            tof_sensor_dvt: vl53l1x@29 {
+                compatible = "st,vl53l1x";
+                reg = <0x29>;
+                zephyr,deferred-init;
+            };
         };
 
         mux_i2c@1 {
@@ -1011,6 +1017,7 @@
     tof_sensor: vl53l1x@29 {
         compatible = "st,vl53l1x";
         reg = <0x29>;
+        zephyr,deferred-init;
     };
 
     // io-expander on the front unit 0x23

--- a/main_board/log_levels.Kconfig
+++ b/main_board/log_levels.Kconfig
@@ -74,6 +74,10 @@ module = BUTTON
 module-str = BUTTON
 source "subsys/logging/Kconfig.template.log_config"
 
+module = OPTICS
+module-str = OPTICS
+source "subsys/logging/Kconfig.template.log_config"
+
 module = TOF_1D
 module-str = TOF_1D
 source "subsys/logging/Kconfig.template.log_config"

--- a/main_board/src/optics/1d_tof/tof_1d.h
+++ b/main_board/src/optics/1d_tof/tof_1d.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <common.pb.h>
 #include <stdbool.h>
 #include <zephyr/kernel.h>
 
@@ -19,4 +20,5 @@ distance_is_safe(void);
  * isn't ready
  */
 int
-tof_1d_init(void (*distance_unsafe_cb)(void), struct k_mutex *mutex);
+tof_1d_init(void (*distance_unsafe_cb)(void), struct k_mutex *mutex,
+            const orb_mcu_Hardware *hw_version);

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -11,7 +11,7 @@
 #include <app_assert.h>
 #include <zephyr/drivers/gpio.h>
 
-LOG_MODULE_REGISTER(optics);
+LOG_MODULE_REGISTER(optics, CONFIG_OPTICS_LOG_LEVEL);
 
 static orb_mcu_HardwareDiagnostic_Status self_test_status =
     orb_mcu_HardwareDiagnostic_Status_STATUS_UNKNOWN;
@@ -79,6 +79,7 @@ optics_safety_circuit_triggered(const uint32_t timeout_ms, bool *triggered)
 __maybe_unused static void
 distance_is_unsafe_cb(void)
 {
+    LOG_INF("⚠️ Distance (1D ToF) is unsafe");
     ir_camera_system_set_on_time_us(0);
 }
 
@@ -113,7 +114,7 @@ optics_init(const orb_mcu_Hardware *hw_version, struct k_mutex *mutex)
     }
 
 #ifdef CONFIG_PROXIMITY_DETECTION_FOR_IR_SAFETY
-    err_code = tof_1d_init(distance_is_unsafe_cb, mutex);
+    err_code = tof_1d_init(distance_is_unsafe_cb, mutex, hw_version);
     if (err_code) {
         ASSERT_SOFT(err_code);
         return err_code;


### PR DESCRIPTION
1d-tof is behind a multiplexer on dvt board
with deferred init to ensure the correct device is initialized.

fixes ORBP-688