### PR TITLE
feat(als): add support for bh1730

### DIFF
--- a/boards/tfh/diamond_main/diamond_main.dts
+++ b/boards/tfh/diamond_main/diamond_main.dts
@@ -384,13 +384,11 @@
             #address-cells = <1>;
             #size-cells = <0>;
 
-            // FIXME: bring back on front unit 6.3D
-            // front_unit_als: bu27030@38 {
-            //     compatible = "rohm,bu27030";
-            //     status = "okay";
-            //     reg = <0x38>;
-            // };
-            //
+            front_unit_als: bh1730@29 {
+                compatible = "rohm,bh1730";
+                status = "okay";
+                reg = <0x29>;
+            };
 
             front_unit_tmp_sensor_shroud_rgb_top: tmp112@48 {
                 compatible = "ti,tmp112";

--- a/main_board/src/temperature/sensors/temperature.c
+++ b/main_board/src/temperature/sensors/temperature.c
@@ -537,7 +537,7 @@ get_ambient_temperature(const struct device *dev, int32_t *temp,
         if (device_is_ready(dev) == false) {
             return RET_ERROR_NOT_INITIALIZED;
         }
-        if (k_mutex_lock(temperature_i2c_mux_mutex, K_MSEC(100)) != 0) {
+        if (k_mutex_lock(temperature_i2c_mux_mutex, K_MSEC(200)) != 0) {
             LOG_ERR("Could not lock mutex.");
             return RET_ERROR_BUSY;
         }

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -482,6 +482,30 @@ update_parameters(orb_mcu_main_UserLEDsPattern_UserRgbLedPattern pattern,
     CRITICAL_SECTION_EXIT(k);
 }
 
+#if defined(CONFIG_BOARD_DIAMOND_MAIN)
+bool
+front_leds_is_shroud_on(void)
+{
+    if (k_sem_take(&leds_update_sem, K_MSEC(1)) == 0) {
+        for (size_t i = 0; i < ARRAY_SIZE(leds.part.center_leds); ++i) {
+            if (leds.part.center_leds[i].scratch != 0 &&
+                (leds.part.center_leds[i].r != 0 ||
+                 leds.part.center_leds[i].g != 0 ||
+                 leds.part.center_leds[i].b != 0)) {
+                k_sem_give(&leds_update_sem);
+                return true;
+            }
+        }
+    } else {
+        return true;
+    }
+
+    k_sem_give(&leds_update_sem);
+
+    return false;
+}
+#endif
+
 ret_code_t
 front_leds_set_pattern(orb_mcu_main_UserLEDsPattern_UserRgbLedPattern pattern,
                        uint32_t start_angle, int32_t angle_length,

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.h
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.h
@@ -13,6 +13,15 @@ ret_code_t
 front_leds_init(void);
 
 /**
+ * Check the LED array for any non-zero LED in the shroud
+ * If the semaphore is not available, shroud is assumed to be on.
+ *
+ * @return true if at least one led is on in the shroud
+ */
+bool
+front_leds_is_shroud_on(void);
+
+/**
  * @brief Set pattern for front LEDs
  * Some arguments are optional because they are not used by some patterns.
  * Make sure to check the pattern documentation.

--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,7 @@ manifest:
     remote: worldcoin
   projects:
     - name: zephyr
-      revision: 98623d948f922dd17be62082fbd070233856c059 # Zephyr 4.1.0 + patches on worldcoin/zephyr
+      revision: 444eda6e0824f3157c3789ffe230064cf1906fb0 # Zephyr 4.1.0 + patches on worldcoin/zephyr
       import:
         name-allowlist:
           - cmsis


### PR DESCRIPTION
mark data with a flag when LED in shroud are turned on, as they are interfering with the ALS measurement.


when hiding the sensor with my hand on the front face (~20 lux without)

```
2025-06-16 14:19:43.832 [00:00:48.994,000] <inf> als: Ambient light:  13.000000 lux
2025-06-16 14:19:44.936 [00:00:50.100,000] <inf> als: Ambient light:  12.000000 lux
2025-06-16 14:19:46.041 [00:00:51.205,000] <inf> als: Ambient light:  20.000000 lux
2025-06-16 14:19:47.144 [00:00:52.311,000] <inf> als: Ambient light:  19.000000 lux
2025-06-16 14:19:48.248 [00:00:53.417,000] <inf> als: Ambient light:  20.000000 lux
```

fixes O-3025