### PR TITLE
chore(dvt): swap polarizer pwm & booster leds pwm pins

### DIFF
--- a/boards/tfh/diamond_main/diamond_main.dts
+++ b/boards/tfh/diamond_main/diamond_main.dts
@@ -72,11 +72,11 @@
         supply-vbat-sw-enable-gpios = <&gpio_exp_pwr_brd 12 GPIO_ACTIVE_HIGH>;
         front-unit-pvcc-enabled-gpios = <&gpio_exp_front_unit 0 GPIO_ACTIVE_HIGH>;
 
+        polarizer-stepper-spi-cs-gpios = <&gpio_exp1 0 GPIO_ACTIVE_LOW>;
         polarizer-stepper-direction-gpios = <&gpio_exp1 1 GPIO_ACTIVE_HIGH>;
         polarizer-stepper-enable-gpios = <&gpio_exp1 2 GPIO_ACTIVE_HIGH>;
         polarizer-stepper-encoder-enable-gpios = <&gpio_exp1 3 GPIO_ACTIVE_LOW>;
         polarizer-stepper-encoder-gpios = <&gpioc 11 GPIO_ACTIVE_HIGH>;
-        polarizer-stepper-spi-cs-gpios = <&gpio_exp1 0 GPIO_ACTIVE_LOW>;
 
         // On Front Unit 6.2 (B3) the signal EN_5V_SWITCHED is connected to the port expander pin P02 instead.
         front-unit-en-5v-switched-gpios = <&gpio_exp_front_unit 2 GPIO_ACTIVE_HIGH>;      // B3 only
@@ -160,14 +160,28 @@
         enable-gpios = <&gpio_exp1 6 GPIO_ACTIVE_HIGH>;
     };
 
+    white_leds_evt {
+        compatible = "pwm-white-leds";
+        pwms = <&white_leds_pwm_evt 2 65535 PWM_POLARITY_NORMAL>;
+        zephyr,deferred-init;
+    };
+
     white_leds {
         compatible = "pwm-white-leds";
         pwms = <&white_leds_pwm 2 65535 PWM_POLARITY_NORMAL>;
+        zephyr,deferred-init;
+    };
+
+    polarizer_step_evt {
+        compatible = "pwm-polarizer-step";
+        pwms = <&polarizer_step_pwm_evt 2 100000 PWM_POLARITY_NORMAL>;
+        zephyr,deferred-init;
     };
 
     polarizer_step {
         compatible = "pwm-polarizer-step";
         pwms = <&polarizer_step_pwm 2 100000 PWM_POLARITY_NORMAL>;
+        zephyr,deferred-init;
     };
 
     liquid_lens {
@@ -853,7 +867,13 @@
         channels = <3>;
     };
 
-    polarizer_step_pwm: pwm {
+    polarizer_step_pwm_evt: pwm {
+        status = "okay";
+        pinctrl-0 = <&tim2_ch2_pd4>;
+        pinctrl-names = "default";
+    };
+
+    white_leds_pwm: pwm {
         status = "okay";
         pinctrl-0 = <&tim2_ch2_pd4>;
         pinctrl-names = "default";
@@ -894,8 +914,16 @@
 
 &timers8 {
     status = "okay";
+    // prescaler needed for polarizer wheel control (16-bit timer)
+    st,prescaler = <1>;
 
-    white_leds_pwm: pwm {
+    white_leds_pwm_evt: pwm {
+        status = "okay";
+        pinctrl-0 = <&tim8_ch2_pc7>;
+        pinctrl-names = "default";
+    };
+
+    polarizer_step_pwm: pwm {
         status = "okay";
         pinctrl-0 = <&tim8_ch2_pc7>;
         pinctrl-names = "default";

--- a/dts/bindings/polarizer_step/pwm-polarizer-step.yaml
+++ b/dts/bindings/polarizer_step/pwm-polarizer-step.yaml
@@ -2,6 +2,8 @@ description: PWM for polarizer step
 
 compatible: "pwm-polarizer-step"
 
+include: [base.yaml]
+
 properties:
   pwms:
     required: true

--- a/dts/bindings/white_leds/pwm-white-leds.yaml
+++ b/dts/bindings/white_leds/pwm-white-leds.yaml
@@ -2,6 +2,8 @@ description: PWM for white LEDs on Front Unit
 
 compatible: "pwm-white-leds"
 
+include: [base.yaml]
+
 properties:
   pwms:
     required: true

--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -282,7 +282,7 @@ initialize(void)
     err_code = sound_init();
     ASSERT_SOFT(err_code);
 
-    err_code = ui_init();
+    err_code = ui_init(&hw);
     ASSERT_SOFT(err_code);
 
     err_code = als_init(&hw, &analog_and_i2c_mutex);

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -117,7 +117,7 @@ optics_init(const orb_mcu_Hardware *hw_version, struct k_mutex *mutex)
     ASSERT_SOFT(err_code);
 
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
-    err_code = polarizer_wheel_init();
+    err_code = polarizer_wheel_init(hw_version);
     ASSERT_SOFT(err_code);
 #endif
 

--- a/main_board/src/optics/polarizer_wheel/polarizer_wheel.h
+++ b/main_board/src/optics/polarizer_wheel/polarizer_wheel.h
@@ -99,7 +99,7 @@ polarizer_wheel_home_async(void);
  * @return Indicates successful initialization
  */
 ret_code_t
-polarizer_wheel_init(void);
+polarizer_wheel_init(const orb_mcu_Hardware *hw_version);
 
 /**
  * Get polarizer status

--- a/main_board/src/ui/ui.c
+++ b/main_board/src/ui/ui.c
@@ -23,7 +23,7 @@ ui_cone_present_send(uint32_t remote)
 }
 
 int
-ui_init(void)
+ui_init(const orb_mcu_Hardware *hw_version)
 {
     int err_code;
 
@@ -34,8 +34,10 @@ ui_init(void)
     ASSERT_SOFT(err_code);
 
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
-    err_code = white_leds_init();
+    err_code = white_leds_init(hw_version);
     ASSERT_SOFT(err_code);
+#else
+    UNUSED_PARAMETER(hw_version);
 #endif
 
     return RET_SUCCESS;

--- a/main_board/src/ui/ui.h
+++ b/main_board/src/ui/ui.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <common.pb.h>
 #include <stdint.h>
 
 /**
@@ -14,4 +15,4 @@ ui_cone_present_send(uint32_t remote);
  * @return error code
  */
 int
-ui_init(void);
+ui_init(const orb_mcu_Hardware *hw_version);

--- a/main_board/src/ui/white_leds/white_leds.h
+++ b/main_board/src/ui/white_leds/white_leds.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <common.pb.h>
 #include <errors.h>
 #include <stdint.h>
 
@@ -7,4 +8,4 @@ ret_code_t
 white_leds_set_brightness(uint32_t brightness_thousandth);
 
 ret_code_t
-white_leds_init(void);
+white_leds_init(const orb_mcu_Hardware *hw_version);


### PR DESCRIPTION
will allow us to use more features from timer8 like step counters, instead of having to keep track of them in ISR

fixes O-3026