### PR TITLE
feat(1d-tof): measure distance at all time

### DIFF
--- a/main_board/src/optics/1d_tof/tof_1d.c
+++ b/main_board/src/optics/1d_tof/tof_1d.c
@@ -159,6 +159,10 @@ tof_1d_init(void (*distance_unsafe_cb)(void), struct k_mutex *mutex,
 {
     int ret;
 
+    if (mutex) {
+        i2c1_mutex = mutex;
+    }
+
 #if CONFIG_BOARD_DIAMOND_MAIN
     /* on diamond, select correct 1d-tof device from device tree as it differs
      * from evt to dvt and initialize it (deferred, to prevent init failures)
@@ -168,8 +172,14 @@ tof_1d_init(void (*distance_unsafe_cb)(void), struct k_mutex *mutex,
         tof_1d_device = tof_1d_device_dvt;
     }
 
+    if (i2c1_mutex) {
+        k_mutex_lock(i2c1_mutex, K_FOREVER);
+    }
     ret = device_init(tof_1d_device);
     ASSERT_SOFT(ret);
+    if (i2c1_mutex) {
+        k_mutex_unlock(i2c1_mutex);
+    }
 #else
     UNUSED_PARAMETER(hw_version);
 #endif
@@ -177,10 +187,6 @@ tof_1d_init(void (*distance_unsafe_cb)(void), struct k_mutex *mutex,
     if (!device_is_ready(tof_1d_device)) {
         LOG_ERR("VL53L1 not ready!");
         return RET_ERROR_INVALID_STATE;
-    }
-
-    if (mutex) {
-        i2c1_mutex = mutex;
     }
 
     k_thread_create(&tof_1d_thread_data, stack_area_tof_1d,

--- a/main_board/src/optics/optics.c
+++ b/main_board/src/optics/optics.c
@@ -113,15 +113,8 @@ optics_init(const orb_mcu_Hardware *hw_version, struct k_mutex *mutex)
         return err_code;
     }
 
-#ifdef CONFIG_PROXIMITY_DETECTION_FOR_IR_SAFETY
     err_code = tof_1d_init(distance_is_unsafe_cb, mutex, hw_version);
-    if (err_code) {
-        ASSERT_SOFT(err_code);
-        return err_code;
-    }
-#else
-    UNUSED_PARAMETER(mutex);
-#endif
+    ASSERT_SOFT(err_code);
 
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
     err_code = polarizer_wheel_init();


### PR DESCRIPTION
even when safety feature is disabled, report 1d tof distances
don't return early on 1d-tof initialization error