### PR TITLE
fix(memfault): battery removed set as expected reboot reason

### DIFF
--- a/main_board/config/memfault_reboot_reason_user_config.def
+++ b/main_board/config/memfault_reboot_reason_user_config.def
@@ -1,4 +1,6 @@
 // Defines "unexpected" reboots
-MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(BatteryRemoved)
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HeartbeatFromJetsonTimeout)
+// "battery removed" is an "expected" reboot reason since too many people are removing the battery
+// with the orb running...
+MEMFAULT_EXPECTED_REBOOT_REASON_DEFINE(BatteryRemoved)
 MEMFAULT_EXPECTED_REBOOT_REASON_DEFINE(JetsonRequestedReboot)


### PR DESCRIPTION
seems like many ppl are removing the battery to turn the orb off ideally we don't want that usage to be widespread but in the meantime, it's bloating our embedded firmware metrics