### PR TITLE
chore(assert): log error only if asked to

### DIFF
--- a/lib/errors/app_assert.c
+++ b/lib/errors/app_assert.c
@@ -115,8 +115,10 @@ app_assert_range(const char *name, const int32_t value, const int32_t min,
 {
     if (range_min != 0 || range_max != 0) {
         if (value < range_min || value > range_max) {
-            LOG_ERR("%s = %d; NOT in range: [%d, %d] (unity: %s)", name, value,
-                    range_min, range_max, unity ? unity : "N/A");
+            if (verbose) {
+                LOG_ERR("%s = %d; NOT in range: [%d, %d] (unity: %s)", name,
+                        value, range_min, range_max, unity ? unity : "N/A");
+            }
             return false;
         } else {
             if (verbose) {


### PR DESCRIPTION
we use the `assert in range` function for voltages. turns out that some voltages are often out of range but the monitors should be on the backend side so that we don't flood with errors.