### PR TITLE
fix(logs): errors on serial for service/dev

### DIFF
--- a/lib/include/orb_logs.h
+++ b/lib/include/orb_logs.h
@@ -21,16 +21,21 @@
 #include <memfault/core/trace_event.h>
 
 /// Log warnings
+/// use MEMFAULT_SDK_LOG_SAVE instead of MEMFAULT_LOG_WARN to bypass
+/// platform logs in memfault call (prefer to call it here, with proper module
+/// name)
 #undef LOG_WRN
 #define LOG_WRN(...)                                                           \
     do {                                                                       \
-        MEMFAULT_LOG_WARN(__VA_ARGS__);                                        \
+        Z_LOG(LOG_LEVEL_WRN, __VA_ARGS__);                                     \
+        MEMFAULT_SDK_LOG_SAVE(kMemfaultPlatformLogLevel_Warning, __VA_ARGS__); \
     } while (0)
 
 /// Each Trace Event will be associated with an Issue.
 #undef LOG_ERR
 #define LOG_ERR(...)                                                           \
     do {                                                                       \
+        Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__);                                     \
         MEMFAULT_TRACE_EVENT_WITH_LOG(error, __VA_ARGS__);                     \
     } while (0)
 

--- a/main_board/src/temperature/sensors/temperature.c
+++ b/main_board/src/temperature/sensors/temperature.c
@@ -649,7 +649,7 @@ sample_and_report_temperature(struct sensor_and_channel *sensor_and_channel)
 
     if (i == TEMPERATURE_SAMPLE_RETRY_COUNT) {
         // We failed after many attempts. Reset the history and try again later
-        LOG_ERR(
+        LOG_WRN(
             "Failed to sample '%s' [source %u], after %d retries. Last ret: %d",
             sensor_and_channel->sensor->name,
             sensor_and_channel->temperature_source,


### PR DESCRIPTION
don't pipe all logs to memfault only
also log errors and warning to serial
decrease log level for temperature errors to warning