### PR TITLE
fix(orb-state): initialize dynamic data

### DIFF
--- a/lib/health_monitoring/Kconfig
+++ b/lib/health_monitoring/Kconfig
@@ -6,3 +6,7 @@ config ORB_LIB_THREAD_STACK_SIZE_HEARTBEAT
     default 512
     help
         "Tweak depending on the heartbeat timeout handler"
+
+config ORB_LIB_SYS_INIT_STATE_PRIORITY
+    int "post-kernel init priority for orb state module"
+    default 50

--- a/lib/health_monitoring/orb_state.c
+++ b/lib/health_monitoring/orb_state.c
@@ -112,3 +112,19 @@ orb_state_set(struct orb_state_dynamic_data *data, const int state,
 
     return 0;
 }
+
+int
+orb_state_init(void)
+{
+    struct orb_state_const_data *data = NULL;
+    while (orb_state_iter(&data)) {
+        ((struct orb_state_dynamic_data *)data->dynamic_data)->status =
+            RET_ERROR_NOT_INITIALIZED;
+        memset(((struct orb_state_dynamic_data *)data->dynamic_data)->message,
+               0, ORB_STATE_MESSAGE_MAX_LENGTH);
+    }
+
+    return 0;
+}
+
+SYS_INIT(orb_state_init, POST_KERNEL, CONFIG_ORB_LIB_SYS_INIT_STATE_PRIORITY);

--- a/main_board/src/system/diag.c
+++ b/main_board/src/system/diag.c
@@ -86,6 +86,7 @@ diag_sync(uint32_t remote)
 
     struct orb_state_const_data *data = NULL;
     while (orb_state_iter(&data)) {
+        memset(&hw_state, 0, sizeof(hw_state));
         memccpy(hw_state.source_name, data->name, '\0',
                 sizeof(hw_state.source_name));
         hw_state.status = data->dynamic_data->status;


### PR DESCRIPTION
do it with sys init, post kernel
so that it's performed before user code
priority defaults to 50