### PR TITLE
fix(ztest): reduce CAN usage

### DIFF
--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -269,7 +269,7 @@ initialize(void)
     ASSERT_SOFT(err_code);
 
     // logs over CAN must be initialized after CAN-messaging module
-#if defined(CONFIG_ORB_LIB_LOGS_CAN)
+#if defined(CONFIG_ORB_LIB_LOGS_CAN) && !CONFIG_NO_JETSON_BOOT
     err_code = logs_init(logs_can);
     ASSERT_SOFT(err_code);
 #endif

--- a/main_board/src/system/diag.c
+++ b/main_board/src/system/diag.c
@@ -71,7 +71,7 @@ diag_sync(uint32_t remote)
 
             // throttle the sending of statuses to avoid flooding the CAN bus
             // and CAN controller
-            if (!IS_ENABLED(CONFIG_ZTEST) && more_data) {
+            if (more_data) {
                 k_msleep(10);
             }
         } while (more_data);
@@ -100,11 +100,9 @@ diag_sync(uint32_t remote)
         }
         counter++;
 
-#ifndef CONFIG_ZTEST
         // throttle the sending of statuses to avoid flooding the CAN bus
         // and CAN controller
         k_msleep(10);
-#endif
     }
     LOG_INF("Sent: %u, errors: %u", counter, error_counter);
 


### PR DESCRIPTION
do not send logs over CAN when we know that jetson isn't used throttle sending orb state in any case (ztest or not)