### PR TITLE
chore(debug): use CONFIG_DEBUG instead of custom defined DEBUG

### DIFF
--- a/bootloader/CMakeLists.txt
+++ b/bootloader/CMakeLists.txt
@@ -21,7 +21,6 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     list(APPEND EXTRA_CONF_FILE "release.conf")
 else ()
     message(STATUS "🧐 Minimal optimization, logging enabled")
-    add_compile_definitions(DEBUG)
 endif ()
 
 # Add a common dts overlay necessary to ensure mcuboot is linked into,

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -339,7 +339,7 @@ do_boot(struct boot_rsp *rsp)
 }
 #endif
 
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
 /**
  * Using the original Zephyr app image can be useful to easily debug the
  * application This image doesn't contain a valid header so this function simply
@@ -595,7 +595,7 @@ main(void)
 
         mcuboot_status_change(MCUBOOT_STATUS_NO_BOOTABLE_IMAGE_FOUND);
 
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
         /* try booting image that doesn't contain a header */
         do_boot_debug();
 #endif

--- a/lib/dfu/dfu.c
+++ b/lib/dfu/dfu.c
@@ -563,7 +563,7 @@ exit:
 int
 dfu_readback_protection(void)
 {
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
     LOG_INF("Skipping readback protection in debug mode");
     return 0;
 #endif

--- a/lib/errors/orb_fatal.c
+++ b/lib/errors/orb_fatal.c
@@ -52,7 +52,7 @@ fatal_get_status_register(void)
     return reset_reason_reg;
 }
 
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
 static void
 print_reset_reason()
 {
@@ -81,7 +81,7 @@ fatal_init(void)
     reset_reason_reg = RCC->CSR;
     WRITE_BIT(RCC->CSR, RCC_CSR_RMVF_Pos, 1);
 
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
     print_reset_reason();
 #endif
 

--- a/lib/watchdog/watchdog.c
+++ b/lib/watchdog/watchdog.c
@@ -83,7 +83,7 @@ watchdog_init(void)
     }
 
     uint8_t opt = 0;
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
     opt |= WDT_OPT_PAUSE_HALTED_BY_DBG;
 #endif
 

--- a/main_board/CMakeLists.txt
+++ b/main_board/CMakeLists.txt
@@ -29,7 +29,6 @@ elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "Service")
 else ()
     message(STATUS "⚙️ Debug image: minimal optimization, debug info included, logging & CLI enabled")
     add_compile_options(-Og -g)
-    add_compile_definitions(DEBUG)
 
     set(OVERLAY_CONFIG
             "debug.conf ${OVERLAY_CONFIG}"

--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -379,7 +379,7 @@ main_internal(void)
     date_print();
 
     // print states and test results
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
     orb_mcu_Hardware hw = version_get();
     LOG_INF("Hardware version: main board: %u, power board: %u, front-unit: "
             "%u, reset board: %u",

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -425,7 +425,7 @@ static K_WORK_DELAYABLE_DEFINE(power_cycle_heatcam_2v8_line_work,
                                power_cycle_heatcam_2v8_line_work_handler);
 #endif
 
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
 
 static void
 power_cycle_wifi_3v3_line_work_handler(struct k_work *item)
@@ -481,7 +481,7 @@ power_cycle_supply(const orb_mcu_main_PowerCycle_Line line,
     }
 
     switch (line) {
-#ifdef DEBUG
+#ifdef CONFIG_DEBUG
     case orb_mcu_main_PowerCycle_Line_WIFI_3V3:
         ret = gpio_pin_configure_dt(&supply_3v3_wifi_enable_gpio_spec,
                                     GPIO_OUTPUT_INACTIVE);


### PR DESCRIPTION
do not rely on user-defined macro but use the already in-place kconfig for debug
fix: service image won't try to set rdp byte