### PR TITLE
refactor(sound): use device tree

### DIFF
--- a/boards/tfh/diamond_main/diamond_main.dts
+++ b/boards/tfh/diamond_main/diamond_main.dts
@@ -1076,6 +1076,12 @@
         zephyr,deferred-init;
     };
 
+    audio_amp: tas5805m@2c {
+        compatible = "vnd,i2c-device";
+        reg = <0x2c>;
+        status = "okay";
+    };
+
     // io-expander on the front unit 0x23
     gpio_exp_front_unit: pca95xx@23 {
         compatible = "nxp,pca95xx";

--- a/boards/tfh/pearl_main/pearl_main.dts
+++ b/boards/tfh/pearl_main/pearl_main.dts
@@ -701,6 +701,12 @@
         compatible = "rohm,bu27030";
         reg = <0x38>;
     };
+
+    audio_amp: tas5805m@2c {
+        compatible = "vnd,i2c-device";
+        reg = <0x2c>;
+        status = "okay";
+    };
 };
 
 &fdcan1 {


### PR DESCRIPTION
to get the amplifier device with i2c address, so that all the devices connected to i2c are defined in the device tree, which is easier to find