### PR TITLE
fix(watchdog): check overridden value that is actually used

### DIFF
--- a/lib/watchdog/watchdog.c
+++ b/lib/watchdog/watchdog.c
@@ -19,8 +19,7 @@ static const struct device *const watchdog_dev =
 #define WATCHDOG_RELOAD_MS CONFIG_ORB_LIB_WATCHDOG_RELOAD_MS
 #endif
 
-BUILD_ASSERT(CONFIG_ORB_LIB_WATCHDOG_RELOAD_MS <
-                 CONFIG_ORB_LIB_WATCHDOG_TIMEOUT_MS,
+BUILD_ASSERT(WATCHDOG_RELOAD_MS < CONFIG_ORB_LIB_WATCHDOG_TIMEOUT_MS,
              "Watchdog reload time must be less than watchdog timeout");
 
 static bool feed = true;


### PR DESCRIPTION
the static assertion was checking the kconfig value, that could be overridden.
Better to check overridden