### PR TITLE
chore(assert): improve ASSERT_HARD usage

### DIFF
--- a/lib/errors/app_assert.c
+++ b/lib/errors/app_assert.c
@@ -37,12 +37,10 @@ fatal(struct k_work *item)
     LOG_ERR("FATAL %s:%d, error %d", fatal_error.error_info.filename,
             fatal_error.error_info.line_num, fatal_error.error_info.err_code);
 
+    /* user callback at the end, in case of stack overflow... */
     if (assert_hard_user_cb) {
         assert_hard_user_cb(&fatal_error.error_info);
     }
-
-    // busy wait for 2 seconds...
-    k_busy_wait(2000000);
 
     HALT_IF_DEBUGGING();
 

--- a/lib/health_monitoring/heartbeat.c
+++ b/lib/health_monitoring/heartbeat.c
@@ -28,8 +28,8 @@ timeout_default_handler(void)
         kMfltRebootReason_HeartbeatFromJetsonTimeout);
 #endif
 
-    ASSERT_HARD(RET_ERROR_TIMEOUT);
-    return RET_ERROR_ASSERT_FAILS;
+    NVIC_SystemReset();
+    CODE_UNREACHABLE;
 }
 
 static void

--- a/main_board/config/memfault_reboot_reason_user_config.def
+++ b/main_board/config/memfault_reboot_reason_user_config.def
@@ -1,5 +1,6 @@
 // Defines "unexpected" reboots
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HeartbeatFromJetsonTimeout)
+MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HardAssert)
 // "battery removed" is an "expected" reboot reason since too many people are removing the battery
 // with the orb running...
 MEMFAULT_EXPECTED_REBOOT_REASON_DEFINE(BatteryRemoved)

--- a/main_board/src/optics/mirror/mirror_private.c
+++ b/main_board/src/optics/mirror/mirror_private.c
@@ -144,7 +144,7 @@ motor_controller_spi_write(uint8_t reg, int32_t value)
     tx.len = sizeof tx_buffer;
 
     int ret = spi_transceive_dt(&spi_bus_dt, &tx_bufs, &rx_bufs);
-    ASSERT_HARD(ret);
+    ASSERT_SOFT(ret);
 
     return RET_SUCCESS;
 }

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -1038,7 +1038,8 @@ boot_turn_on_jetson(void)
         LOG_ERR(
             "Jetson cannot boot, ensure it's correctly connected & functional");
         k_msleep(1000);
-        ASSERT_HARD(RET_ERROR_INVALID_STATE);
+        NVIC_SystemReset();
+        CODE_UNREACHABLE;
         // 💀
     } else {
         LOG_INF("Jetson is booting");

--- a/main_board/src/ui/rgb_leds/front_leds/front_leds.c
+++ b/main_board/src/ui/rgb_leds/front_leds/front_leds.c
@@ -140,9 +140,12 @@ set_center(struct led_rgb color)
 static void
 set_ring(struct led_rgb color, uint32_t start_angle, int32_t angle_length)
 {
-    ASSERT_HARD_BOOL(start_angle < FULL_RING_DEGREES);
-    ASSERT_HARD_BOOL(angle_length <= FULL_RING_DEGREES &&
-                     angle_length >= -FULL_RING_DEGREES);
+    if (start_angle >= FULL_RING_DEGREES || angle_length > FULL_RING_DEGREES ||
+        angle_length < -FULL_RING_DEGREES) {
+        LOG_ERR("invalid: start angle: %u, angle length: %u", start_angle,
+                angle_length);
+        return;
+    }
 
     // get first LED index, based on LED at 0º on trigonometric circle
     size_t led_index =


### PR DESCRIPTION
use memfault to log hard assertion failures
decrease usage of it, prefer ASSERT_SOFT or logging errors hard assert might end up being reset with a watchdog and so incorrectly logged.
added reboot reason HardAssert