### PR TITLE
fix(logs): do not send logs on can tx error

### DIFF
--- a/lib/can_messaging/canbus_tx.c
+++ b/lib/can_messaging/canbus_tx.c
@@ -69,7 +69,6 @@ send(const char *data, size_t len,
     if (ret) {
         // -ENETDOWN(-115) can happen if 3v3 lost during transmission
         // CAN will recover when 3v3 back on
-        LOG_ERR("err: %i", ret);
         if (ret == -ENETUNREACH) {
             can_messaging_resume();
         }


### PR DESCRIPTION
logs are eventually sent over CAN so this might just loop indefinitely with logs not being sent because of the state of the CAN bus