### PR TITLE
feat(diamond): add security MCU reboot request

### DIFF
--- a/boards/tfh/diamond_main/diamond_main.dts
+++ b/boards/tfh/diamond_main/diamond_main.dts
@@ -121,6 +121,9 @@
 
         // for gpio based tachometer (coarse estimation)
         fan-main-tach-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+
+        // request security MCU reboot
+        exp-mcu-rst-rqst-gpios = <&gpio_exp1 11 GPIO_ACTIVE_HIGH>;
     };
 
     buttons {

--- a/main_board/src/cli/cli.c
+++ b/main_board/src/cli/cli.c
@@ -2,6 +2,7 @@
 
 #include "date.h"
 #include "dfu.h"
+#include "errors.h"
 #include "mcu_ping.h"
 #include "orb_logs.h"
 #include "system/config/config.h"
@@ -457,6 +458,43 @@ execute_date(const struct shell *sh, size_t argc, char **argv)
 }
 
 #ifdef CONFIG_BOARD_DIAMOND_MAIN
+
+static int
+execute_reboot_sec_mcu(const struct shell *sh, size_t argc, char **argv)
+{
+    UNUSED_PARAMETER(argc);
+    UNUSED_PARAMETER(argv);
+
+    orb_mcu_Hardware hw_revision = version_get();
+    if (hw_revision.version <
+        orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_V4_5) {
+        shell_error(sh, "not supported on this hardware version: %u",
+                    hw_revision.version);
+        return RET_ERROR_NOT_SUPPORTED;
+    }
+
+    orb_mcu_main_JetsonToMcu message = {
+        .which_payload = orb_mcu_main_JetsonToMcu_reboot_security_mcu_tag,
+    };
+
+    shell_print(sh, "Requesting security MCU reboot");
+    return runner_handle_new_cli(&message);
+}
+
+static int
+execute_reboot_sec_mcu(const struct shell *sh, size_t argc, char **argv)
+{
+    UNUSED_PARAMETER(argc);
+    UNUSED_PARAMETER(argv);
+
+    orb_mcu_main_JetsonToMcu message = {
+        .which_payload = orb_mcu_main_JetsonToMcu_reboot_security_mcu_tag,
+    };
+
+    shell_print(sh, "Requesting security MCU reboot");
+    return runner_handle_new_cli(&message);
+}
+
 static int
 execute_white_leds(const struct shell *sh, size_t argc, char **argv)
 {
@@ -861,6 +899,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #ifdef CONFIG_BOARD_DIAMOND_MAIN
     SHELL_CMD(white_leds, NULL, "Control white LEDs", execute_white_leds),
     SHELL_CMD(polarizer, NULL, "Control polarizer wheel", execute_polarizer),
+    SHELL_CMD(reboot_sec, NULL, "Reboot security MCU", execute_reboot_sec_mcu),
 #endif
     SHELL_CMD(boot_config, NULL, "Get/set boot behavior (button|always_on)",
               execute_boot_config),

--- a/main_board/src/power/boot/boot.c
+++ b/main_board/src/power/boot/boot.c
@@ -111,9 +111,10 @@ static const struct gpio_dt_spec supply_3v6_enable_gpio_spec =
     GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), supply_3v6_enable_gpios);
 static const struct gpio_dt_spec supply_5v_rgb_enable_gpio_spec =
     GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), supply_5v_rgb_enable_gpios);
-
 static const struct gpio_dt_spec usb_hub_reset_gpio_spec =
     GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), usb_hub_reset_gpios);
+static const struct gpio_dt_spec exp_mcu_rst_rqst_gpio_spec =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), exp_mcu_rst_rqst_gpios);
 #endif
 
 static K_SEM_DEFINE(sem_reboot, 0, 1);
@@ -359,6 +360,17 @@ power_configure_gpios(void)
     if (ret != 0) {
         ASSERT_SOFT(ret);
         return RET_ERROR_INTERNAL;
+    }
+
+    if (version.version >=
+        orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_V4_5) {
+        if (!gpio_is_ready_dt(&exp_mcu_rst_rqst_gpio_spec)) {
+            LOG_ERR("GPIO for security MCU reset request not ready");
+            return RET_ERROR_INTERNAL;
+        }
+        ret = gpio_pin_configure_dt(&exp_mcu_rst_rqst_gpio_spec,
+                                    GPIO_OUTPUT_INACTIVE);
+        ASSERT_SOFT(ret);
     }
 #endif
 

--- a/main_board/src/runner/runner.c
+++ b/main_board/src/runner/runner.c
@@ -32,12 +32,8 @@
 #include <stdlib.h>
 #include <uart_messaging.h>
 #include <ui/rgb_leds/front_leds/front_leds.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
-
-#if defined(CONFIG_BOARD_DIAMOND_MAIN)
-#include "ui/rgb_leds/cone_leds/cone_leds.h"
-#include "ui/white_leds/white_leds.h"
-#endif
 
 #if defined(CONFIG_MEMFAULT_METRICS_CONNECTIVITY_CONNECTED_TIME)
 #include <memfault/metrics/connectivity.h>
@@ -48,6 +44,28 @@
 #endif
 
 LOG_MODULE_REGISTER(runner, CONFIG_RUNNER_LOG_LEVEL);
+
+#if defined(CONFIG_BOARD_DIAMOND_MAIN)
+#include "ui/rgb_leds/cone_leds/cone_leds.h"
+#include "ui/white_leds/white_leds.h"
+
+static const struct gpio_dt_spec exp_mcu_rst_rqst_gpio_spec =
+    GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), exp_mcu_rst_rqst_gpios);
+
+static void
+exp_mcu_rst_rqst_deassert_work_handler(struct k_work *work)
+{
+    ARG_UNUSED(work);
+
+    int ret = gpio_pin_set_dt(&exp_mcu_rst_rqst_gpio_spec, 0);
+    if (ret != 0) {
+        LOG_ERR("Failed to deassert reboot request GPIO: %d", ret);
+    }
+}
+
+static K_WORK_DELAYABLE_DEFINE(exp_mcu_rst_rqst_deassert_work,
+                               exp_mcu_rst_rqst_deassert_work_handler);
+#endif
 
 K_THREAD_STACK_DEFINE(runner_process_stack, THREAD_STACK_SIZE_RUNNER);
 static struct k_thread runner_process;
@@ -1197,6 +1215,41 @@ handle_power_cycle(job_t *job)
 
 #ifdef CONFIG_BOARD_DIAMOND_MAIN
 static void
+handle_reboot_security_mcu(job_t *job)
+{
+    orb_mcu_main_JetsonToMcu *msg = &job->message.jetson_cmd;
+    MAKE_ASSERTS(orb_mcu_main_JetsonToMcu_reboot_security_mcu_tag);
+
+    int ret;
+
+    orb_mcu_Hardware hw_revision = version_get();
+    if (hw_revision.version <
+        orb_mcu_Hardware_OrbVersion_HW_VERSION_DIAMOND_V4_5) {
+        job_ack(orb_mcu_Ack_ErrorCode_VERSION, job);
+        return;
+    }
+
+    if (!gpio_is_ready_dt(&exp_mcu_rst_rqst_gpio_spec)) {
+        LOG_ERR("GPIO for security MCU reset request not ready");
+        job_ack(orb_mcu_Ack_ErrorCode_FAIL, job);
+        return;
+    }
+
+    ret =
+        gpio_pin_configure_dt(&exp_mcu_rst_rqst_gpio_spec, GPIO_OUTPUT_ACTIVE);
+    if (ret != 0) {
+        LOG_ERR("Failed to set GPIO high: %d", ret);
+        job_ack(orb_mcu_Ack_ErrorCode_FAIL, job);
+        return;
+    }
+
+    k_work_schedule(&exp_mcu_rst_rqst_deassert_work, K_MSEC(1000));
+
+    LOG_INF("Security MCU reboot requested");
+    job_ack(orb_mcu_Ack_ErrorCode_SUCCESS, job);
+}
+
+static void
 handle_polarizer(job_t *job)
 {
     orb_mcu_main_JetsonToMcu *msg = &job->message.jetson_cmd;
@@ -1834,6 +1887,8 @@ static const hm_callback handle_message_callbacks[] = {
     [orb_mcu_main_JetsonToMcu_polarizer_tag] = handle_polarizer,
     [orb_mcu_main_JetsonToMcu_polarizer_wheel_settings_tag] =
         handle_polarizer_wheel_settings,
+    [orb_mcu_main_JetsonToMcu_reboot_security_mcu_tag] =
+        handle_reboot_security_mcu,
 #elif defined(CONFIG_BOARD_PEARL_MAIN)
     [orb_mcu_main_JetsonToMcu_cone_leds_sequence_tag] = handle_not_supported,
     [orb_mcu_main_JetsonToMcu_cone_leds_pattern_tag] = handle_not_supported,
@@ -1843,7 +1898,7 @@ static const hm_callback handle_message_callbacks[] = {
 #endif
 };
 
-BUILD_ASSERT((ARRAY_SIZE(handle_message_callbacks) <= 57),
+BUILD_ASSERT((ARRAY_SIZE(handle_message_callbacks) <= 58),
              "It seems like the `handle_message_callbacks` array is too large");
 
 _Noreturn static void

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
       remote: memfault
       revision: 1.31.0
     - name: orb-messages
-      revision: af472fadb57ce55ac63f8f94bd2a0608e62405c7
+      revision: 3cb63e197d02cecf993314c2f15bead7db898e17
       path: modules/orb-messages/public
     - name: priv-orb-messages
       revision: 0da6bab271385e952813bfcbef9ce9bf38b0f27a


### PR DESCRIPTION
Allow the Jetson or CLI to request a security MCU reboot by having the main MCU drive EXP_MCU_RST_RQST_3V3 GPIO high for 100ms.

- Add exp-mcu-rst-rqst-gpios to diamond_main DTS (gpio_exp1 pin 11)
- Add handle_reboot_security_mcu handler in runner.c
- Add `orb reboot_sec` CLI command (Diamond only)