### PR TITLE
feat: reboot the orb if there's no messages for 10 min

### DIFF
--- a/main_board/Kconfig
+++ b/main_board/Kconfig
@@ -27,6 +27,25 @@ config DT_HAS_DIAMOND_CONE_ENABLED
 	def_bool $(dt_nodelabel_enabled,cone_spi_bridge)
 	select SC18IS606
 
+config JETSON_FIRST_MESSAGE_TIMEOUT
+    bool "Reset the Orb if Jetson never sends a message after boot"
+    depends on BOARD_DIAMOND_MAIN
+    default y
+    help
+      If no Jetson message is received within
+      CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT_S of the Jetson being powered on,
+      assume it's dead/unresponsive and reset the MCU (NVIC_SystemReset),
+      which power-cycles the whole Orb.
+
+config JETSON_FIRST_MESSAGE_TIMEOUT_S
+    int "Timeout before JETSON_FIRST_MESSAGE_TIMEOUT resets the Orb"
+    depends on JETSON_FIRST_MESSAGE_TIMEOUT
+    default 600
+    help
+      Number of seconds after the Jetson is powered on to wait for the
+      first Jetson message before resetting the Orb. Overridable per build
+      (e.g. for bench/HIL verification without waiting 10 minutes).
+
 comment "Developer options"
 
 config HIL_TESTS

--- a/main_board/config/memfault_reboot_reason_user_config.def
+++ b/main_board/config/memfault_reboot_reason_user_config.def
@@ -1,5 +1,6 @@
 // Defines "unexpected" reboots
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HeartbeatFromJetsonTimeout)
+MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(JetsonFirstMessageTimeout)
 MEMFAULT_UNEXPECTED_REBOOT_REASON_DEFINE(HardAssert)
 // "battery removed" is an "expected" reboot reason since too many people are removing the battery
 // with the orb running...

--- a/main_board/src/main.c
+++ b/main_board/src/main.c
@@ -199,6 +199,35 @@ heartbeat_timeout_handler(void)
     return 0;
 }
 
+#if defined(CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT)
+static int
+jetson_first_message_timeout_handler(void)
+{
+    if (runner_jetson_messages_count() > 0) {
+        return 0;
+    }
+
+    const int32_t shutdown_delay_ms = 5000;
+    const orb_mcu_main_ShutdownScheduled shutdown = {
+        .shutdown_reason =
+            orb_mcu_main_ShutdownScheduled_ShutdownReason_HEARTBEAT_TIMEOUT,
+        .ms_until_shutdown = shutdown_delay_ms};
+    publish_new((void *)&shutdown, sizeof(shutdown),
+                orb_mcu_main_McuToJetson_shutdown_tag,
+                CONFIG_CAN_ADDRESS_MCU_TO_JETSON_TX);
+
+    k_msleep(shutdown_delay_ms);
+
+#ifdef CONFIG_MEMFAULT
+    MEMFAULT_REBOOT_MARK_RESET_IMMINENT(
+        kMfltRebootReason_JetsonFirstMessageTimeout);
+#endif
+
+    NVIC_SystemReset();
+    return 0;
+}
+#endif
+
 static void
 send_reset_reason(void)
 {
@@ -243,12 +272,19 @@ __maybe_unused static void
 wait_jetson_up(void)
 {
     LOG_INF("Waiting for messages from the Jetson...");
+#if defined(CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT)
+    const int64_t wait_started_ms = k_uptime_get();
+    const int64_t timeout_ms =
+        (int64_t)CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT_S * MSEC_PER_SEC;
+#endif
+
     // wait for Jetson to show activity before sending our version
     while (!jetson_up_and_running) {
         k_msleep(5000);
+        const uint32_t jetson_messages_count = runner_jetson_messages_count();
 
         // as soon as the Jetson sends the first message, send firmware version
-        if (runner_successful_jobs_count() > 0) {
+        if (jetson_messages_count > 0) {
             version_fw_send(CONFIG_CAN_ADDRESS_MCU_TO_JETSON_TX);
 
             uint32_t error_count = app_assert_soft_count();
@@ -260,6 +296,15 @@ wait_jetson_up(void)
 
             jetson_up_and_running = true;
         }
+
+#if defined(CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT)
+        if (jetson_messages_count == 0 &&
+            (k_uptime_get() - wait_started_ms) > timeout_ms) {
+            LOG_ERR("No message received from Jetson within %us, resetting Orb",
+                    CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT_S);
+            jetson_first_message_timeout_handler();
+        }
+#endif
     }
 }
 

--- a/main_board/src/runner/runner.c
+++ b/main_board/src/runner/runner.c
@@ -33,6 +33,7 @@
 #include <uart_messaging.h>
 #include <ui/rgb_leds/front_leds/front_leds.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
 
 #if defined(CONFIG_BOARD_DIAMOND_MAIN)
 #include "ui/rgb_leds/cone_leds/cone_leds.h"
@@ -56,6 +57,7 @@ static k_tid_t runner_tid = NULL;
 #define MAKE_ASSERTS(tag) ASSERT_SOFT_BOOL(msg->which_payload == tag)
 
 static uint32_t job_counter = 0;
+static atomic_t jetson_message_counter = ATOMIC_INIT(0);
 
 enum remote_type_e {
     CAN_JETSON_MESSAGING,
@@ -97,6 +99,12 @@ uint32_t
 runner_successful_jobs_count(void)
 {
     return job_counter;
+}
+
+uint32_t
+runner_jetson_messages_count(void)
+{
+    return (uint32_t)atomic_get(&jetson_message_counter);
 }
 
 static void
@@ -1952,6 +1960,7 @@ runner_handle_new_can(can_message_t *msg)
         if (decoded) {
             if (mcu_message.which_message == orb_mcu_McuMessage_j_message_tag) {
                 // Handle Jetson messages
+                atomic_inc(&jetson_message_counter);
                 new.remote = CAN_JETSON_MESSAGING;
                 new.message.jetson_cmd = mcu_message.message.j_message;
                 new.ack_number = mcu_message.message.j_message.ack_number;

--- a/main_board/src/runner/runner.h
+++ b/main_board/src/runner/runner.h
@@ -13,6 +13,13 @@ uint32_t
 runner_successful_jobs_count(void);
 
 /**
+ * @brief Get the number of received Jetson messages
+ * @return number of received Jetson messages
+ */
+uint32_t
+runner_jetson_messages_count(void);
+
+/**
  * Queue new message to be processed, from CAN bus
  *
  * @note The function blocks 5ms if the queue is full.


### PR DESCRIPTION
https://linear.app/worldcoin/issue/ORBS-1681/mcu-timeouts-lead-to-orb-core-restarts-in-prod

The idea is to reboot the orb, if main MCU doesn't receive any hw_revision requests for 10 minutes.

There is a oneshot worldcoin-create-hardware-version.service that sends this specific request at startup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cold-boot and Jetson bring-up behavior on production Diamond hardware by forcing a full MCU reset after a long silence; mis-tuned timeouts or counting only CAN (not UART) Jetson traffic could cause unwanted reboots in slow-boot or test scenarios.
> 
> **Overview**
> Adds **Jetson first-message timeout** recovery on Diamond: if the main MCU still has not received any decoded Jetson CAN message after `CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT_S` (default **600s**), it notifies the Jetson with `ShutdownScheduled` (heartbeat-timeout reason), waits 5s, records **Memfault** `JetsonFirstMessageTimeout`, and triggers **`NVIC_SystemReset`** to power-cycle the Orb. The feature is gated by **`CONFIG_JETSON_FIRST_MESSAGE_TIMEOUT`** (`BOARD_DIAMOND_MAIN`, default on).
> 
> **Boot wait logic** in `wait_jetson_up()` now treats Jetson as alive when **`runner_jetson_messages_count() > 0`** instead of **`runner_successful_jobs_count() > 0`**, so the first inbound Jetson message (e.g. startup hw/version `ValueGet`) counts even before a job completes with a successful ACK.
> 
> The runner increments an **atomic Jetson message counter** when a CAN protobuf `j_message` is decoded and queued, exposed via **`runner_jetson_messages_count()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d4da397b289ec6536d3ff9c49bb8fbfde4c12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->